### PR TITLE
Cumulative-logit PACS: math note + exact (Option B) implementation + LRT + tests

### DIFF
--- a/.github/workflows/R-CMD-check.yaml
+++ b/.github/workflows/R-CMD-check.yaml
@@ -1,0 +1,47 @@
+## R CMD check on push and PR. Mirrors r-lib/actions standard template,
+## ubuntu-latest single OS to keep CI cost low. Does not run --as-cran to
+## avoid noise from existing examples / PICsnATAC remote.
+
+name: R-CMD-check
+
+on:
+  push:
+    branches: [main, master]
+  pull_request:
+    branches: [main, master]
+  workflow_dispatch:
+
+jobs:
+  R-CMD-check:
+    runs-on: ubuntu-latest
+    env:
+      GITHUB_PAT: ${{ secrets.GITHUB_TOKEN }}
+      R_KEEP_PKG_SOURCE: yes
+      _R_CHECK_FORCE_SUGGESTS_: false
+    steps:
+      - uses: actions/checkout@v4
+
+      - uses: r-lib/actions/setup-pandoc@v2
+
+      - uses: r-lib/actions/setup-r@v2
+        with:
+          use-public-rspm: true
+
+      - uses: r-lib/actions/setup-r-dependencies@v2
+        with:
+          extra-packages: |
+            any::rcmdcheck
+            any::testthat
+            any::devtools
+          needs: check
+
+      - name: Regenerate documentation
+        run: |
+          options(repos = c(CRAN = "https://cloud.r-project.org"))
+          devtools::document(roclets = c("rd", "namespace"))
+        shell: Rscript {0}
+
+      - uses: r-lib/actions/check-r-package@v2
+        with:
+          upload-snapshots: true
+          args: 'c("--no-manual")'

--- a/R/PACS_test_cumulative.R
+++ b/R/PACS_test_cumulative.R
@@ -20,6 +20,11 @@
 #'   null model, we do not
 #'   need to specify unless there are reasons to do so. Default = NULL
 #' @param n_cores number of cores for multi-core computation
+#' @param method One of `"stacked"` (default, back-compat) or `"exact"`.
+#'   `"stacked"` uses the original stack-and-treat-as-binary approximation.
+#'   `"exact"` uses the proper cumulative-logit likelihood with capture-rate
+#'   correction (Option B in `notes/cumulative_logit_math.md`); valid LRT df
+#'   and unbiased β estimates.
 #'
 #' @return A list of two elements, pacs_converged is a vector
 #'   of length 2*n_peaks representing the convergence status
@@ -31,7 +36,23 @@
 pacs_test_cumu <- function(covariate_meta.data, formula_full,
                            formula_null, pic_matrix, max_T = 2,
                            cap_rates, par_initial_null = NULL,
-                           par_initial_full = NULL, n_cores = 1) {
+                           par_initial_full = NULL, n_cores = 1,
+                           method = c("stacked", "exact")) {
+  method <- match.arg(method)
+  if (method == "exact") {
+    return(pacs_test_cumu_exact(
+      covariate_meta.data = covariate_meta.data,
+      formula_full = formula_full,
+      formula_null = formula_null,
+      pic_matrix = pic_matrix,
+      max_T = max_T,
+      cap_rates = cap_rates,
+      par_initial_null = par_initial_null,
+      par_initial_full = par_initial_full,
+      n_cores = n_cores
+    ))
+  }
+
   ### construct model matrix
   X_full <- model.matrix(formula_full, data = covariate_meta.data)
   X_null <- model.matrix(formula_null, data = covariate_meta.data)
@@ -140,4 +161,96 @@ pacs_test_cumu <- function(covariate_meta.data, formula_full,
 
 
   return(list(pacs_converged = conv_mat, pacs_p_val = pacs_p_val))
+}
+
+
+## Exact-likelihood path. Internal driver invoked from pacs_test_cumu when
+## method = "exact". See notes/cumulative_logit_math.md for the model;
+## fitting routines live in R/param_estimate_cumu.R.
+pacs_test_cumu_exact <- function(covariate_meta.data, formula_full,
+                                 formula_null, pic_matrix, max_T,
+                                 cap_rates, par_initial_null,
+                                 par_initial_full, n_cores) {
+  X_full <- model.matrix(formula_full, data = covariate_meta.data)
+  X_null <- model.matrix(formula_null, data = covariate_meta.data)
+
+  ## Strip leading intercept columns (alpha plays the intercept role per
+  ## threshold). Both formulas should produce a leading "(Intercept)" column.
+  if ("(Intercept)" %in% colnames(X_full)) {
+    X_full <- X_full[, setdiff(colnames(X_full), "(Intercept)"), drop = FALSE]
+  }
+  if ("(Intercept)" %in% colnames(X_null)) {
+    X_null <- X_null[, setdiff(colnames(X_null), "(Intercept)"), drop = FALSE]
+  }
+
+  ## Identify parameters of interest (in full but not null) and re-order so
+  ## they sit at the end of the design matrix.
+  pars_of_interest <- setdiff(colnames(X_full), colnames(X_null))
+  if (length(pars_of_interest) == 0L) {
+    stop("formula_full and formula_null have the same covariates; nothing to test.")
+  }
+  X_full <- X_full[, c(colnames(X_null), pars_of_interest), drop = FALSE]
+  p_beta <- ncol(X_full)
+  T <- max_T
+
+  ## hold_zero indices in the full theta = (atilde_1..T, beta_1..p):
+  ## thresholds always free; betas of interest set to zero under null.
+  beta_poi_idx <- which(colnames(X_full) %in% pars_of_interest)
+  hold_zero <- T + beta_poi_idx
+
+  ## Initial values: warm-start atilde from the entry-pooled empirical
+  ## marginals of pic_matrix; beta = 0. Single shared starting point for
+  ## all peaks (matches the binary path's `par_initial = rep.int(0.05, n)`
+  ## convention).
+  if (is.null(par_initial_full) || length(par_initial_full) != T + p_beta) {
+    M_pool <- as.numeric(if ("sparseMatrix" %in% is(pic_matrix)) {
+      as.matrix(pic_matrix)
+    } else {
+      pic_matrix
+    })
+    par_initial_full <- warm_start_theta(
+      M = M_pool, q = cap_rates, T = T, p_beta = p_beta
+    )
+  }
+  if (is.null(par_initial_null)) {
+    par_initial_null <- par_initial_full
+  } else if (length(par_initial_null) != T + p_beta) {
+    par_initial_null <- par_initial_full
+  }
+  par_initial_null[hold_zero] <- 0
+
+  null_para <- estimate_parameters_cumu_null(
+    r_by_c = pic_matrix, X = X_full, theta_initial = par_initial_null,
+    hold_zero = hold_zero, q_vec = cap_rates, T = T, mc.cores = n_cores
+  )
+  full_para <- estimate_parameters_cumu(
+    r_by_c = pic_matrix, X = X_full, theta_initial = par_initial_full,
+    q_vec = cap_rates, T = T, mc.cores = n_cores
+  )
+
+  conv_mat <- c(
+    null_para[nrow(null_para), ],
+    full_para[nrow(full_para), ]
+  )
+  null_para <- null_para[seq_len(nrow(null_para) - 1L), , drop = FALSE]
+  full_para <- full_para[seq_len(nrow(full_para) - 1L), , drop = FALSE]
+
+  if ("sparseMatrix" %in% is(pic_matrix)) {
+    M_dense <- as.matrix(pic_matrix)
+  } else {
+    M_dense <- pic_matrix
+  }
+  c_by_r <- t(M_dense)
+
+  pacs_p_val <- compare_models_cumu(
+    x_full = X_full,
+    theta_estimated_full = full_para,
+    theta_estimated_null = null_para,
+    q_vec = cap_rates, c_by_r = c_by_r, T = T,
+    df_test = length(beta_poi_idx),
+    mc.cores = n_cores
+  )
+  names(pacs_p_val) <- rownames(pic_matrix)
+
+  list(pacs_converged = conv_mat, pacs_p_val = pacs_p_val)
 }

--- a/R/differential_identification.R
+++ b/R/differential_identification.R
@@ -54,13 +54,21 @@ compare_models_cumu <- function(x_full, theta_estimated_full,
 
   ## Boundary check (math note §9): warn if any fitted exp(atilde_t) for
   ## t >= 2 is essentially zero, indicating an active order constraint.
+  ## Threshold 1e-3 corresponds to alpha_{t-1} - alpha_t < 0.001, which
+  ## is effectively zero on the logit scale (cumulative probabilities at
+  ## adjacent thresholds differ by less than ~0.025 percentage points
+  ## near p = 0.5). At that point the Self-Liang mixture-of-chi-square
+  ## regime applies and the standard chi^2 p-value over-estimates
+  ## significance. Tunable via `boundary_eps` if exposed; see math note
+  ## §9 for the full discussion.
+  boundary_eps <- 1e-3
   if (T >= 2L) {
     a_block_full <- theta_estimated_full[2:T, , drop = FALSE]
-    near_boundary <- which(apply(exp(a_block_full) < 1e-3, 2, any))
+    near_boundary <- which(apply(exp(a_block_full) < boundary_eps, 2, any))
     if (length(near_boundary) > 0L) {
       warning(sprintf(
-        "%d peak(s) hit the order-constraint boundary; chi-square approximation may be unreliable.",
-        length(near_boundary)
+        "%d peak(s) hit the order-constraint boundary (exp(atilde_t) < %g); chi-square approximation may be unreliable.",
+        length(near_boundary), boundary_eps
       ))
     }
   }

--- a/R/differential_identification.R
+++ b/R/differential_identification.R
@@ -1,5 +1,74 @@
 ### differential_identification
 
+
+## Penalised LRT under the exact cumulative-logit model (method = "exact" in
+## pacs_test_cumu). Mirrors compare_models() below but evaluates the
+## cumulative-logit penalised log-likelihood per peak via
+## loss_fun_star_cumu(); fitting routines live in R/param_estimate_cumu.R
+## and the math is in notes/cumulative_logit_math.md (§9).
+##
+## Args:
+##   x_full              : n × p design matrix (alpha-free; alpha lives in theta).
+##   theta_estimated_full: (T + p) × n_features matrix of fitted thetas (full).
+##   theta_estimated_null: (T + p) × n_features matrix of fitted thetas (null).
+##   q_vec               : length-n capture rates.
+##   c_by_r              : n × n_features observed-count matrix.
+##   T                   : number of thresholds.
+##   df_test             : degrees of freedom = number of beta components held
+##                         to zero under null (thresholds are shared).
+##   mc.cores            : passed to mclapply.
+compare_models_cumu <- function(x_full, theta_estimated_full,
+                                theta_estimated_null,
+                                q_vec, c_by_r, T, df_test,
+                                mc.cores = 1L) {
+  if ("sparseMatrix" %in% is(c_by_r)) {
+    c_by_r <- as.matrix(c_by_r)
+  }
+  n_features <- ncol(theta_estimated_full)
+  if (n_features != ncol(c_by_r)) {
+    stop("theta dimension does not match c_by_r")
+  }
+
+  per_peak <- function(j) {
+    M_j <- as.numeric(c_by_r[, j])
+    th_full <- theta_estimated_full[, j]
+    th_null <- theta_estimated_null[, j]
+    ## Penalised log-likelihoods at the two MLEs.
+    I_full <- try(infor_mat_cumu(th_full, x_full, q_vec, T), silent = TRUE)
+    I_null <- try(infor_mat_cumu(th_null, x_full, q_vec, T), silent = TRUE)
+    if (inherits(I_full, "try-error") || inherits(I_null, "try-error")) {
+      return(NA_real_)
+    }
+    ll_full <- loss_fun_star_cumu(th_full, x_full, M_j, q_vec, T,
+                                  inf_mat = I_full)
+    ll_null <- loss_fun_star_cumu(th_null, x_full, M_j, q_vec, T,
+                                  inf_mat = I_null)
+    if (!is.finite(ll_full) || !is.finite(ll_null)) return(NA_real_)
+    stat <- 2 * (ll_full - ll_null)
+    if (stat < 0) stat <- 0
+    pchisq(stat, df = df_test, lower.tail = FALSE)
+  }
+
+  pvals <- unlist(parallel::mclapply(seq_len(n_features), per_peak,
+                                     mc.cores = mc.cores))
+
+  ## Boundary check (math note §9): warn if any fitted exp(atilde_t) for
+  ## t >= 2 is essentially zero, indicating an active order constraint.
+  if (T >= 2L) {
+    a_block_full <- theta_estimated_full[2:T, , drop = FALSE]
+    near_boundary <- which(apply(exp(a_block_full) < 1e-3, 2, any))
+    if (length(near_boundary) > 0L) {
+      warning(sprintf(
+        "%d peak(s) hit the order-constraint boundary; chi-square approximation may be unreliable.",
+        length(near_boundary)
+      ))
+    }
+  }
+
+  pvals
+}
+
+
 #' Compute loss function with Firth regularization from Wii matrix
 #'
 #' @param wii_sqrt The square root of Wii diagonal elements as a vector

--- a/R/param_estimate_cumu.R
+++ b/R/param_estimate_cumu.R
@@ -429,10 +429,14 @@ estimate_parameters_cumu <- function(r_by_c, X, theta_initial, q_vec, T,
   }
   cells_by_region <- t(r_by_c)
   cells_by_region <- as.list(as.data.frame(cells_by_region))
-  res <- parallel::mclapply(cells_by_region,
-                            FUN = irls_iter_cumu,
-                            X = X, theta_estimated = theta_initial,
-                            q_vec = q_vec, T = T, mc.cores = mc.cores)
+  ## Closure avoids name collision between mclapply's first parameter `X`
+  ## and the design matrix `X` we need to pass to irls_iter_cumu.
+  fit_one <- function(M_vec) {
+    irls_iter_cumu(M_vec, X = X, theta_estimated = theta_initial,
+                   q_vec = q_vec, T = T)
+  }
+  res <- parallel::mclapply(cells_by_region, FUN = fit_one,
+                            mc.cores = mc.cores)
   do.call(cbind, res)
 }
 
@@ -444,10 +448,11 @@ estimate_parameters_cumu_null <- function(r_by_c, X, theta_initial, hold_zero,
   }
   cells_by_region <- t(r_by_c)
   cells_by_region <- as.list(as.data.frame(cells_by_region))
-  res <- parallel::mclapply(cells_by_region,
-                            FUN = irls_iter_cumu_null,
-                            X = X, theta_estimated = theta_initial,
-                            hold_zero = hold_zero,
-                            q_vec = q_vec, T = T, mc.cores = mc.cores)
+  fit_one <- function(M_vec) {
+    irls_iter_cumu_null(M_vec, X = X, theta_estimated = theta_initial,
+                        hold_zero = hold_zero, q_vec = q_vec, T = T)
+  }
+  res <- parallel::mclapply(cells_by_region, FUN = fit_one,
+                            mc.cores = mc.cores)
   do.call(cbind, res)
 }

--- a/R/param_estimate_cumu.R
+++ b/R/param_estimate_cumu.R
@@ -267,6 +267,14 @@ infor_mat_cumu <- function(theta, X, q, T) {
 ## --- Firth penalty (numerical FD on ∂I/∂θ_r) -----------------------------
 
 ## Penalty score: 0.5 * tr(I^{-1} ∂I/∂θ_r), r = 1..(T + p_beta).
+##
+## Phase 1 uses central finite differences on infor_mat_cumu, which costs
+## 2*(T + p_beta) Fisher-info evaluations per IRLS step. This is the
+## dominant cost of the inner loop and is responsible for the loosened
+## 1e-4 tolerance in the T=1 IRLS parity test (vs. 1e-10 for the
+## individual loss/score/info parity). An analytic ∂I/∂θ_r is in
+## scope for a follow-up using ∂u_{it}/∂η = u_{it}(1 − 2 p_{it}); see
+## the math note §5 and follow-up issue tracking the replacement.
 loss_grad_pen_cumu <- function(theta, X, q, T,
                                inf_mat = NULL, h = 1e-5) {
   if (is.null(inf_mat)) inf_mat <- infor_mat_cumu(theta, X, q, T)

--- a/R/param_estimate_cumu.R
+++ b/R/param_estimate_cumu.R
@@ -1,0 +1,445 @@
+## Cumulative-logit PACS, exact (Option B)
+##
+## Implements the proper proportional-odds likelihood with cell-level
+## all-or-nothing capture (notes/cumulative_logit_math.md, §3.1, §4.1, §5.1,
+## §6, §7). Internal helpers; the public surface is pacs_test_cumu.
+##
+## At T = 1 these functions reduce term-for-term to loss_fun, loss_gradient,
+## infor_mat in R/param-estimate_logit_get_p_by_t_June.R; tests in
+## tests/testthat/test-cumu-T1-parity.R verify this.
+
+
+is_error_cumu <- function(x) inherits(x, "try-error")
+
+
+## --- reparameterisation ---------------------------------------------------
+
+## ã -> α with α_1 = ã_1, α_t = ã_1 - sum_{s=2..t} exp(ã_s).
+## Strictly enforces α_1 >= α_2 >= ... >= α_T.
+alpha_from_atilde <- function(atilde) {
+  T <- length(atilde)
+  if (T == 1L) return(atilde)
+  alpha <- numeric(T)
+  alpha[1] <- atilde[1]
+  cs <- cumsum(exp(atilde[2:T]))
+  alpha[2:T] <- atilde[1] - cs
+  alpha
+}
+
+## Jacobian J = ∂α/∂ã. Lower-triangular: J[,1] = 1, J[t,s] = -exp(ã_s) for
+## 2 <= s <= t, zero otherwise.
+atilde_jacobian <- function(atilde) {
+  T <- length(atilde)
+  J <- matrix(0, nrow = T, ncol = T)
+  J[, 1] <- 1
+  if (T >= 2L) {
+    e <- exp(atilde[2:T])
+    for (s in 2:T) {
+      J[s:T, s] <- -e[s - 1]
+    }
+  }
+  J
+}
+
+## Block Jacobian for θ = (ã, β): blkdiag(J, I_p).
+full_jacobian <- function(atilde, p_beta) {
+  T <- length(atilde)
+  Jt <- atilde_jacobian(atilde)
+  m <- T + p_beta
+  J <- matrix(0, nrow = m, ncol = m)
+  J[1:T, 1:T] <- Jt
+  if (p_beta > 0L) {
+    diag(J)[(T + 1):m] <- 1
+  }
+  J
+}
+
+
+## --- link-function quantities --------------------------------------------
+
+## Compute p_{it}, u_{it}, Delta_{it}, D_{it} given current (α, β).
+## Conventions: p_{i,0} = 1, p_{i,T+1} = 0, u_{i,0} = u_{i,T+1} = 0.
+##
+## Returns a list with n×T matrices p, u, Delta, D.
+cumu_link <- function(alpha, beta, X) {
+  n <- nrow(X)
+  T <- length(alpha)
+  if (length(beta) > 0L) {
+    xb <- as.numeric(X %*% beta)
+  } else {
+    xb <- rep.int(0, n)
+  }
+  ## eta[i, t] = α_t + x_i^T β, so p[i, t] = σ(eta).
+  eta <- outer(xb, alpha, FUN = "+")
+  p <- 1 / (1 + exp(-eta))
+  u <- p * (1 - p)
+  ## Delta[i, t] = p[i, t] - p[i, t+1] with p[, T+1] = 0.
+  if (T >= 2L) {
+    Delta <- cbind(p[, -T, drop = FALSE] - p[, -1, drop = FALSE], p[, T])
+  } else {
+    Delta <- p
+  }
+  ## D[i, t] = u[i, t] - u[i, t+1] with u[, T+1] = 0.
+  if (T >= 2L) {
+    D <- cbind(u[, -T, drop = FALSE] - u[, -1, drop = FALSE], u[, T])
+  } else {
+    D <- u
+  }
+  list(p = p, u = u, Delta = Delta, D = D)
+}
+
+
+## --- log-likelihood (Option B) -------------------------------------------
+
+## Per-cell log Pr(M_i | x_i, q_i) under Option B (note §3.1). Drops the
+## constant log q_i term for m_i >= 1 (irrelevant to optimisation).
+loss_fun_cumu <- function(theta, X, M, q, T) {
+  alpha <- alpha_from_atilde(theta[1:T])
+  beta <- if (length(theta) > T) theta[(T + 1):length(theta)] else numeric(0)
+  L <- cumu_link(alpha, beta, X)
+  Delta <- L$Delta
+  p1 <- L$p[, 1]
+  ll <- numeric(length(M))
+  zero <- (M == 0L)
+  if (any(zero)) {
+    ll[zero] <- log(1 - q[zero] * p1[zero])
+  }
+  if (any(!zero)) {
+    idx <- which(!zero)
+    delta_picked <- Delta[cbind(idx, M[idx])]
+    ll[idx] <- log(delta_picked)
+  }
+  sum(ll)
+}
+
+
+## --- score in (α, β) -----------------------------------------------------
+
+## Returns a length-(T + p_beta) vector: ∂ℓ / ∂(α, β) evaluated at
+## (alpha, beta). Used internally; loss_gradient_cumu wraps with the
+## reparameterisation.
+score_alpha_beta <- function(alpha, beta, X, M, q, link = NULL) {
+  T <- length(alpha)
+  p_beta <- length(beta)
+  n <- length(M)
+  if (is.null(link)) link <- cumu_link(alpha, beta, X)
+  p1 <- link$p[, 1]
+  u  <- link$u
+  Delta <- link$Delta
+  D <- link$D
+
+  s_alpha <- numeric(T)
+  s_beta <- numeric(p_beta)
+
+  zero <- (M == 0L)
+  ## ----- m_i = 0 -----
+  if (any(zero)) {
+    iz <- which(zero)
+    coef_zero <- -q[iz] * u[iz, 1] / (1 - q[iz] * p1[iz])
+    s_alpha[1] <- s_alpha[1] + sum(coef_zero)
+    if (p_beta > 0L) {
+      s_beta <- s_beta + as.numeric(crossprod(X[iz, , drop = FALSE], coef_zero))
+    }
+  }
+  ## ----- m_i >= 1 -----
+  if (any(!zero)) {
+    inz <- which(!zero)
+    Mi <- M[inz]
+    delta_pick <- Delta[cbind(inz, Mi)]
+    ## ∂ℓ/∂β = (D_{i,M_i} / Delta_{i,M_i}) x_i
+    D_pick <- D[cbind(inz, Mi)]
+    coef_beta <- D_pick / delta_pick
+    if (p_beta > 0L) {
+      s_beta <- s_beta + as.numeric(crossprod(X[inz, , drop = FALSE], coef_beta))
+    }
+    ## ∂ℓ/∂α_t = u_{it}/Delta_{i,M_i} · 1[t=M_i] - u_{it}/Delta_{i,M_i} · 1[t=M_i+1]
+    ## Group cells by Mi for vectorised accumulation.
+    for (m in unique(Mi)) {
+      sub <- which(Mi == m)
+      cells <- inz[sub]
+      delt <- delta_pick[sub]
+      ## t = m contribution (positive)
+      s_alpha[m] <- s_alpha[m] + sum(u[cells, m] / delt)
+      ## t = m + 1 contribution (negative), only if m + 1 <= T
+      if ((m + 1L) <= T) {
+        s_alpha[m + 1L] <- s_alpha[m + 1L] - sum(u[cells, m + 1L] / delt)
+      }
+    }
+  }
+
+  c(s_alpha, s_beta)
+}
+
+
+## Score in θ = (ã, β): apply the Jacobian transform score_θ = J̃^T · score_(α,β).
+loss_gradient_cumu <- function(theta, X, M, q, T) {
+  atilde <- theta[1:T]
+  alpha <- alpha_from_atilde(atilde)
+  beta <- if (length(theta) > T) theta[(T + 1):length(theta)] else numeric(0)
+  s_ab <- score_alpha_beta(alpha, beta, X, M, q)
+  J <- full_jacobian(atilde, length(beta))
+  as.numeric(crossprod(J, s_ab))
+}
+
+
+## --- Fisher information in (α, β) (Option B, §5.1) -----------------------
+
+infor_mat_alpha_beta <- function(alpha, beta, X, q, link = NULL) {
+  T <- length(alpha)
+  p_beta <- length(beta)
+  n <- nrow(X)
+  if (is.null(link)) link <- cumu_link(alpha, beta, X)
+  p <- link$p; u <- link$u; Delta <- link$Delta; D <- link$D
+  p1 <- p[, 1]
+
+  ## ν_{i,0} = q^2 u_{i,1}^2 / (1 - q p_{i,1}); contribution from m=0.
+  nu0 <- q^2 * u[, 1]^2 / (1 - q * p1)
+
+  ## ----- α-block (tridiagonal) -----
+  I_aa <- matrix(0, nrow = T, ncol = T)
+  ## diagonal
+  I_aa[1, 1] <- sum(q * u[, 1]^2 / Delta[, 1]) + sum(nu0)
+  if (T >= 2L) {
+    for (t in 2:T) {
+      I_aa[t, t] <- sum(q * u[, t]^2 / Delta[, t]) +
+                    sum(q * u[, t]^2 / Delta[, t - 1])
+    }
+    ## off-diagonal (super-diagonal; symmetric copy below)
+    for (t in 1:(T - 1L)) {
+      val <- -sum(q * u[, t] * u[, t + 1] / Delta[, t])
+      I_aa[t, t + 1L] <- val
+      I_aa[t + 1L, t] <- val
+    }
+  }
+
+  ## ----- β-block -----
+  if (p_beta > 0L) {
+    v <- nu0
+    for (k in 1:T) {
+      v <- v + q * D[, k]^2 / Delta[, k]
+    }
+    I_bb <- crossprod(X, v * X)  ## == X^T diag(v) X, numerically stable since v >= 0.
+  } else {
+    I_bb <- matrix(0, 0, 0)
+  }
+
+  ## ----- α-β cross-block -----
+  if (p_beta > 0L) {
+    I_ab <- matrix(0, nrow = T, ncol = p_beta)
+    ## t = 1: w_{i,1} = q u_{i,1} D_{i,1}/Δ_{i,1} + ν_{i,0}
+    w1 <- q * u[, 1] * D[, 1] / Delta[, 1] + nu0
+    I_ab[1, ] <- as.numeric(crossprod(X, w1))
+    if (T >= 2L) {
+      for (t in 2:T) {
+        w_t <- q * u[, t] * D[, t] / Delta[, t] -
+               q * u[, t] * D[, t - 1] / Delta[, t - 1]
+        I_ab[t, ] <- as.numeric(crossprod(X, w_t))
+      }
+    }
+  } else {
+    I_ab <- matrix(0, T, 0)
+  }
+
+  ## Assemble.
+  m <- T + p_beta
+  I <- matrix(0, nrow = m, ncol = m)
+  I[1:T, 1:T] <- I_aa
+  if (p_beta > 0L) {
+    I[1:T, (T + 1):m] <- I_ab
+    I[(T + 1):m, 1:T] <- t(I_ab)
+    I[(T + 1):m, (T + 1):m] <- I_bb
+  }
+  I
+}
+
+
+## Information matrix in θ = (ã, β): I_θ = J̃^T I_(α,β) J̃.
+infor_mat_cumu <- function(theta, X, q, T) {
+  atilde <- theta[1:T]
+  alpha <- alpha_from_atilde(atilde)
+  beta <- if (length(theta) > T) theta[(T + 1):length(theta)] else numeric(0)
+  I_ab <- infor_mat_alpha_beta(alpha, beta, X, q)
+  J <- full_jacobian(atilde, length(beta))
+  crossprod(J, I_ab) %*% J
+}
+
+
+## --- Firth penalty (numerical FD on ∂I/∂θ_r) -----------------------------
+
+## Penalty score: 0.5 * tr(I^{-1} ∂I/∂θ_r), r = 1..(T + p_beta).
+loss_grad_pen_cumu <- function(theta, X, q, T,
+                               inf_mat = NULL, h = 1e-5) {
+  if (is.null(inf_mat)) inf_mat <- infor_mat_cumu(theta, X, q, T)
+  m <- length(theta)
+  i_inv <- try(solve(inf_mat), silent = TRUE)
+  if (is_error_cumu(i_inv)) return(rep.int(NA_real_, m))
+  out <- numeric(m)
+  for (r in seq_len(m)) {
+    th_p <- theta; th_p[r] <- th_p[r] + h
+    th_m <- theta; th_m[r] <- th_m[r] - h
+    I_p <- infor_mat_cumu(th_p, X, q, T)
+    I_m <- infor_mat_cumu(th_m, X, q, T)
+    dI <- (I_p - I_m) / (2 * h)
+    out[r] <- 0.5 * sum(diag(i_inv %*% dI))
+  }
+  out
+}
+
+
+## Penalised log-likelihood loss + 0.5 log det I.
+loss_fun_star_cumu <- function(theta, X, M, q, T, inf_mat = NULL) {
+  ll <- loss_fun_cumu(theta, X, M, q, T)
+  if (is.null(inf_mat)) inf_mat <- infor_mat_cumu(theta, X, q, T)
+  ld <- determinant.matrix(inf_mat, logarithm = TRUE)
+  if (ld$sign[1] <= 0) return(-Inf)
+  ll + 0.5 * as.numeric(ld$modulus)
+}
+
+
+## --- warm-start from data ------------------------------------------------
+
+## §7 initialisation. Returns θ = (ã, β = 0) of length T + p_beta.
+warm_start_theta <- function(M, q, T, p_beta, eps = 1e-3) {
+  q_mean <- mean(q)
+  alpha_hat <- numeric(T)
+  for (t in 1:T) {
+    rate <- mean(M >= t) / max(q_mean, eps)
+    rate <- min(max(rate, eps), 1 - eps)
+    alpha_hat[t] <- log(rate / (1 - rate))
+  }
+  ## Enforce strict ordering before mapping to ã.
+  if (T >= 2L) {
+    for (t in 2:T) {
+      if (alpha_hat[t] >= alpha_hat[t - 1] - eps) {
+        alpha_hat[t] <- alpha_hat[t - 1] - eps
+      }
+    }
+  }
+  atilde <- numeric(T)
+  atilde[1] <- alpha_hat[1]
+  if (T >= 2L) {
+    for (t in 2:T) {
+      atilde[t] <- log(max(eps, alpha_hat[t - 1] - alpha_hat[t]))
+    }
+  }
+  c(atilde, rep.int(0, p_beta))
+}
+
+
+## --- IRLS (Fisher scoring on ã, β) ---------------------------------------
+
+## Mirrors irls_iter() in R/param-estimate_logit_get_p_by_t_June.R: loops
+## over Newton steps using I^{-1} (score_lik + score_pen), with the same
+## convergence semantics (1 = converged, 2 = singular, 3 = max-iter).
+irls_iter_cumu <- function(M_vec, X, theta_estimated, q_vec, T,
+                           tolerance = .Machine$double.eps^0.5,
+                           stop_criteria = 1e-6, max_iter = 25L) {
+  indi <- 1
+  n_iter <- 1L
+  conv_stat <- 1L
+  while (indi >= stop_criteria && n_iter <= max_iter) {
+    inf_mat <- infor_mat_cumu(theta_estimated, X, q_vec, T)
+    ld <- determinant.matrix(inf_mat, logarithm = TRUE)
+    if (ld$sign[1] <= 0 || as.numeric(ld$modulus) < log(tolerance)) {
+      conv_stat <- 2L
+      break
+    }
+    s_lik <- loss_gradient_cumu(theta_estimated, X, M_vec, q_vec, T)
+    s_pen <- loss_grad_pen_cumu(theta_estimated, X, q_vec, T, inf_mat = inf_mat)
+    if (anyNA(s_lik) || anyNA(s_pen)) {
+      conv_stat <- 2L
+      break
+    }
+    inf_inv <- try(solve(inf_mat), silent = TRUE)
+    if (is_error_cumu(inf_inv)) {
+      conv_stat <- 2L
+      break
+    }
+    update <- as.numeric(inf_inv %*% (s_lik + s_pen))
+    theta_update <- theta_estimated + update
+    indi <- sum((theta_update - theta_estimated)^2)
+    theta_estimated <- theta_update
+    n_iter <- n_iter + 1L
+  }
+  if (indi >= stop_criteria) conv_stat <- 3L
+  c(as.vector(theta_estimated), conv_stat)
+}
+
+
+## Null-fit version: hold a subset of θ at zero (mirrors irls_iter_null).
+irls_iter_cumu_null <- function(M_vec, X, theta_estimated, hold_zero,
+                                q_vec, T,
+                                tolerance = .Machine$double.eps^0.5,
+                                stop_criteria = 1e-6, max_iter = 25L) {
+  indi <- 1
+  n_iter <- 1L
+  conv_stat <- 1L
+  poi <- setdiff(seq_along(theta_estimated), hold_zero)
+  zero_augment <- rep.int(0, length(hold_zero))
+  while (indi >= stop_criteria && n_iter <= max_iter) {
+    inf_mat <- infor_mat_cumu(theta_estimated, X, q_vec, T)
+    ld <- determinant.matrix(inf_mat[poi, poi, drop = FALSE], logarithm = TRUE)
+    if (ld$sign[1] <= 0 || as.numeric(ld$modulus) < log(tolerance)) {
+      conv_stat <- 2L
+      break
+    }
+    s_lik <- loss_gradient_cumu(theta_estimated, X, M_vec, q_vec, T)
+    s_pen <- loss_grad_pen_cumu(theta_estimated, X, q_vec, T, inf_mat = inf_mat)
+    if (anyNA(s_lik) || anyNA(s_pen)) {
+      conv_stat <- 2L
+      break
+    }
+    s_total <- s_lik + s_pen
+    inf_inv <- try(solve(inf_mat[poi, poi, drop = FALSE]), silent = TRUE)
+    if (is_error_cumu(inf_inv)) {
+      conv_stat <- 2L
+      break
+    }
+    update_poi <- as.numeric(inf_inv %*% s_total[poi])
+    update_full <- numeric(length(theta_estimated))
+    update_full[poi] <- update_poi
+    update_full[hold_zero] <- 0
+    theta_update <- theta_estimated + update_full
+    indi <- sum((theta_update - theta_estimated)^2)
+    theta_estimated <- theta_update
+    n_iter <- n_iter + 1L
+  }
+  if (indi >= stop_criteria) conv_stat <- 3L
+  c(as.vector(theta_estimated), conv_stat)
+}
+
+
+## --- per-feature drivers --------------------------------------------------
+
+## Mirrors estimate_parameters() shape: takes a region-by-cell matrix and
+## fits irls_iter_cumu per region. Returns (T+p+1) × n_features matrix
+## where the last row is the convergence code.
+estimate_parameters_cumu <- function(r_by_c, X, theta_initial, q_vec, T,
+                                     mc.cores = 1L) {
+  if ("sparseMatrix" %in% is(r_by_c)) {
+    r_by_c <- as.matrix(r_by_c)
+  }
+  cells_by_region <- t(r_by_c)
+  cells_by_region <- as.list(as.data.frame(cells_by_region))
+  res <- parallel::mclapply(cells_by_region,
+                            FUN = irls_iter_cumu,
+                            X = X, theta_estimated = theta_initial,
+                            q_vec = q_vec, T = T, mc.cores = mc.cores)
+  do.call(cbind, res)
+}
+
+
+estimate_parameters_cumu_null <- function(r_by_c, X, theta_initial, hold_zero,
+                                          q_vec, T, mc.cores = 1L) {
+  if ("sparseMatrix" %in% is(r_by_c)) {
+    r_by_c <- as.matrix(r_by_c)
+  }
+  cells_by_region <- t(r_by_c)
+  cells_by_region <- as.list(as.data.frame(cells_by_region))
+  res <- parallel::mclapply(cells_by_region,
+                            FUN = irls_iter_cumu_null,
+                            X = X, theta_estimated = theta_initial,
+                            hold_zero = hold_zero,
+                            q_vec = q_vec, T = T, mc.cores = mc.cores)
+  do.call(cbind, res)
+}

--- a/R/sim_cumu.R
+++ b/R/sim_cumu.R
@@ -1,0 +1,64 @@
+## Simulator for cumulative-logit PACS data with capture rate.
+##
+## Internal helper used by tests/testthat/ and (optionally) vignettes.
+## Not exported.
+
+
+## Sample M_i from the Option B observed-count distribution.
+##
+## With probability q_i, draw Y_i from the proportional-odds multinomial
+## defined by (alpha, beta), and set M_i = Y_i.
+## With probability 1 - q_i, set M_i = 0.
+##
+## Args:
+##   X      : n × p covariate matrix (no intercept; alpha plays that role).
+##   alpha  : length-T threshold vector with alpha_1 >= ... >= alpha_T.
+##   beta   : length-p slope vector.
+##   q      : length-n capture rates.
+##   capture: "B" only (Option A is deferred per the math note's plan).
+##
+## Returns: integer vector of length n.
+simulate_cumu_pacs <- function(X, alpha, beta, q, capture = "B", seed = NULL) {
+  if (capture != "B") {
+    stop("Only capture = 'B' is implemented; Option A (thinning) is deferred.")
+  }
+  if (!is.null(seed)) set.seed(seed)
+  n <- nrow(X)
+  p <- ncol(X)
+  T <- length(alpha)
+  if (length(beta) != p) {
+    stop("length(beta) must equal ncol(X).")
+  }
+  if (any(diff(alpha) > 0)) {
+    stop("alpha must satisfy alpha_1 >= alpha_2 >= ... >= alpha_T.")
+  }
+  if (length(q) != n) {
+    stop("length(q) must equal nrow(X).")
+  }
+
+  xb <- as.numeric(X %*% beta)
+  ## Cumulative probabilities Pr(Y >= t | x) for t = 1..T.
+  P_ge <- matrix(0, nrow = n, ncol = T)
+  for (t in 1:T) {
+    P_ge[, t] <- 1 / (1 + exp(-(alpha[t] + xb)))
+  }
+  ## Category probabilities pi_{ik} for k = 0..T.
+  pi_mat <- matrix(0, nrow = n, ncol = T + 1L)
+  pi_mat[, 1] <- 1 - P_ge[, 1]                       ## k = 0
+  if (T >= 2L) {
+    for (k in 1:(T - 1L)) {
+      pi_mat[, k + 1L] <- P_ge[, k] - P_ge[, k + 1L] ## k = 1..T-1
+    }
+  }
+  pi_mat[, T + 1L] <- P_ge[, T]                      ## k = T
+
+  ## Sample Y_i from the per-row categorical, then drop to 0 with prob 1-q_i.
+  Y <- integer(n)
+  for (i in seq_len(n)) {
+    Y[i] <- sample.int(T + 1L, size = 1L, prob = pi_mat[i, ]) - 1L
+  }
+  drop <- runif(n) > q
+  M <- Y
+  M[drop] <- 0L
+  M
+}

--- a/notes/cumulative_logit_math.md
+++ b/notes/cumulative_logit_math.md
@@ -130,9 +130,13 @@ Let `Δ_{ik} = p_{ik} − p_{i,k+1}` and `D_{ik} = u_{ik} − u_{i,k+1}` (with
 
 ```
 ∂ℓ_i/∂β   = D_{i,m_i} / Δ_{i,m_i} · x_i,
-∂ℓ_i/∂α_t = ( u_{it} / Δ_{i,m_i} ) · 1[t = m_i]
-            − ( u_{it} / Δ_{i,m_i} ) · 1[t = m_i + 1].
+∂ℓ_i/∂α_t = (u_{i,m_i}   / Δ_{i,m_i}) · 1[t = m_i]
+            − (u_{i,m_i+1} / Δ_{i,m_i}) · 1[t = m_i + 1].
 ```
+
+(The numerator differs in the two indicator branches — `u_{i,m_i}` for the
+`t = m_i` term and `u_{i,m_i+1}` for the `t = m_i + 1` term — because
+`∂p_{ik}/∂α_t = u_{ik}·1[k = t]`.)
 
 For cells with `m_i = 0`:
 
@@ -387,6 +391,15 @@ active at the optimum (i.e. some `exp(ã_t)` is at the lower clip), the
 parameter is on the boundary and the LRT follows a mixture of χ²
 distributions per Self–Liang. In practice we should flag fits that hit the
 clip and either widen the clip or report a warning rather than a p-value.
+
+**Boundary detection threshold.** `compare_models_cumu` flags peaks where
+any `exp(ã_t) < 1e−3` for `t ≥ 2`. At that threshold,
+`α_{t−1} − α_t < 0.001`, which is effectively zero on the logit scale —
+adjacent cumulative probabilities differ by less than ~0.025 percentage
+points near `p = 0.5`. The threshold is conservative; tightening it (say
+`1e−4`) would suppress fewer peaks but risk false negatives on borderline
+fits. We can expose this as an argument once usage patterns clarify
+whether tuning is needed.
 
 ## 10. Implementation plan
 

--- a/notes/cumulative_logit_math.md
+++ b/notes/cumulative_logit_math.md
@@ -1,0 +1,414 @@
+# Cumulative-logit PACS — exact likelihood with capture-rate correction
+
+This note replaces the current "stack-and-treat-as-binary" approximation in
+`R/PACS_test_cumulative.R` with a proper cumulative-logit formulation that
+handles the per-cell capture rate `q_i` consistently with the existing binary
+model in `R/PACS_test_logit.R`.
+
+The derivation here is the prerequisite for an implementation; no code is
+changed by this document.
+
+## 1. Notation
+
+- Cells indexed by `i = 1, ..., n`, with covariate row `x_i ∈ R^p` and
+  per-cell capture rate `q_i ∈ (0, 1]`.
+- Latent (uncaptured) ordinal response `Y_i ∈ {0, 1, ..., T}`. In snATAC,
+  `Y_i` is the count of accessible fragments at a peak before sequencing
+  thinning.
+- Observed response `M_i ∈ {0, 1, ..., T}` after capture by the sequencing
+  protocol.
+- Threshold parameters `α = (α_1, ..., α_T)` with the proportional-odds
+  ordering `α_1 ≥ α_2 ≥ ... ≥ α_T`.
+- Slope `β ∈ R^p`. We collect `θ = (α^T, β^T)^T`.
+- Logistic link `σ(η) = 1 / (1 + e^{-η})`.
+
+For each `t = 1, ..., T` define
+
+```
+p_{it} = Pr(Y_i ≥ t | x_i) = σ(α_t + x_i^T β),
+```
+
+with conventions `p_{i,0} ≡ 1` and `p_{i,T+1} ≡ 0`. The category
+probabilities are
+
+```
+π_{ik} = p_{ik} − p_{i,k+1},   k = 0, 1, ..., T.
+```
+
+Useful derivatives:
+
+```
+∂p_{it}/∂β  = p_{it}(1 − p_{it}) x_i ≡ u_{it} x_i,
+∂p_{it}/∂α_s = u_{it} · 1[s = t].
+```
+
+## 2. Capture model
+
+The binary PACS model uses `Pr(M = 1) = q_i p_i`, `Pr(M = 0) = 1 − q_i p_i`.
+There are two natural extensions to the ordinal case; both reduce to the
+binary model at `T = 1`.
+
+### Option A — fragment-level thinning (matches biology)
+
+Each underlying fragment is independently captured with probability `q_i`,
+i.e. `M_i | Y_i = k ~ Binomial(k, q_i)`. Then
+
+```
+Pr(M_i = m | x_i, q_i)
+   = Σ_{k = m}^{T} C(k, m) q_i^m (1 − q_i)^{k − m} · π_{ik},
+```
+
+where `C(k, m) = k! / (m! (k − m)!)`.
+
+### Option B — cell-level all-or-nothing capture (computationally simpler)
+
+With probability `q_i` the cell is observed perfectly and `M_i = Y_i`; with
+probability `1 − q_i` the cell drops out completely and `M_i = 0`. Then
+
+```
+Pr(M_i = 0 | x_i, q_i) = 1 − q_i p_{i1},
+Pr(M_i = m | x_i, q_i) = q_i (p_{im} − p_{i,m+1}),   1 ≤ m ≤ T.
+```
+
+### Tradeoff
+
+Option A is the natural generalisation of the binary capture model and the
+correct statistical treatment of fragment-level dropout. Option B is more
+tractable (no Binomial mixture), and at high counts where capture is the
+limiting factor it understates the rate at which a high-`Y_i` cell can produce
+a moderate `M_i`. Empirically, for `T = 2` the two differ only when
+`p_{i2}` is appreciable; for snATAC peak-level data where counts ≥ 2 are rare,
+Option B is usually adequate.
+
+A subtle interpretive point: Option B forces "low observed counts" to mean
+"truly less accessible" plus "truly inaccessible at all", with the dropout
+mass parked entirely on `M = 0`. Option A spreads the dropout mass across
+`m = 0, 1, ..., k − 1` proportionally to `Binomial(k, q_i)`, so a cell with
+`Y_i = 3` that loses one fragment still contributes to `M_i = 2`, not to
+`M_i = 0`.
+
+We will implement **Option B first** as a drop-in replacement (parity check at
+`T = 1` against existing binary PACS) and add Option A as a second pass.
+
+## 3. Log-likelihood
+
+Per cell, log-density `ℓ_i(θ) = log Pr(M_i = m_i | x_i, q_i, θ)`.
+
+### 3.1 Option B
+
+```
+ℓ_i =  1[m_i = 0]   · log(1 − q_i p_{i1})
+     + 1[m_i ≥ 1]   · [ log q_i + log(p_{i,m_i} − p_{i,m_i + 1}) ].
+```
+
+The `log q_i` term depends only on data and `q_i`; it is constant in `θ` for
+fixed data and can be dropped from optimisation.
+
+### 3.2 Option A
+
+```
+ℓ_i = log Σ_{k = m_i}^{T} w_{ik} (p_{ik} − p_{i,k+1}),
+w_{ik} = C(k, m_i) q_i^{m_i} (1 − q_i)^{k − m_i}.
+```
+
+Define the posterior over the latent count given the observed count:
+
+```
+γ_{ik} = w_{ik} (p_{ik} − p_{i,k+1}) / Σ_{j ≥ m_i} w_{ij} (p_{ij} − p_{i,j+1}),
+         k = m_i, ..., T,    Σ_k γ_{ik} = 1.
+```
+
+`γ_{ik}` will play the role of E-step posteriors when computing the score,
+Hessian, and Fisher information.
+
+## 4. Score equations
+
+### 4.1 Option B
+
+Let `Δ_{ik} = p_{ik} − p_{i,k+1}` and `D_{ik} = u_{ik} − u_{i,k+1}` (with
+`u_{i,0} = u_{i,T+1} = 0`). For cells with `m_i ≥ 1`:
+
+```
+∂ℓ_i/∂β   = D_{i,m_i} / Δ_{i,m_i} · x_i,
+∂ℓ_i/∂α_t = ( u_{it} / Δ_{i,m_i} ) · 1[t = m_i]
+            − ( u_{it} / Δ_{i,m_i} ) · 1[t = m_i + 1].
+```
+
+For cells with `m_i = 0`:
+
+```
+∂ℓ_i/∂β   = − q_i u_{i1} / (1 − q_i p_{i1}) · x_i,
+∂ℓ_i/∂α_1 = − q_i u_{i1} / (1 − q_i p_{i1}),
+∂ℓ_i/∂α_t = 0   for t ≥ 2.
+```
+
+Edge case `m_i = T`: by convention `p_{i,T+1} = 0` and `u_{i,T+1} = 0`,
+so `Δ_{i,T} = p_{iT}` and `D_{i,T} = u_{iT}`. The score reduces to
+`(u_{iT}/p_{iT}) x_i = (1 − p_{iT}) x_i` for `β`, and `u_{iT}/p_{iT}` for
+`α_T`.
+
+At `T = 1` these collapse to the existing binary PACS score in
+`loss_gradient`.
+
+### 4.2 Option A
+
+Let `r_{ik} = (u_{ik} − u_{i,k+1}) / (p_{ik} − p_{i,k+1})`. Then
+
+```
+∂ℓ_i/∂β   = ( Σ_{k ≥ m_i} γ_{ik} · r_{ik} ) · x_i,
+∂ℓ_i/∂α_t = γ_{it} · u_{it} / Δ_{it}
+            − γ_{i,t−1} · u_{it} / Δ_{i,t−1},
+```
+
+with the convention `γ_{i,m_i − 1} ≡ 0`.
+
+## 5. Observed information / Hessian
+
+Write `L_i = exp(ℓ_i)`. Then
+
+```
+−∂² log L_i / ∂θ ∂θ^T = − L_i^{-1} ∂² L_i / ∂θ ∂θ^T  +  S_i S_i^T,
+```
+
+where `S_i = ∂ℓ_i/∂θ`. The needed second derivatives of `L_i` involve only
+
+```
+∂u_{it}/∂η_{it} = u_{it} (1 − 2 p_{it}),
+```
+
+with `η_{it} = α_t + x_i^T β`. All terms are closed-form.
+
+### 5.1 Fisher information under Option B (block structure)
+
+We compute the *expected* information
+
+```
+I(θ) = E_M [ S(θ) S(θ)^T ] = Σ_i Σ_m Pr(M_i = m | x_i, q_i, θ) · s_{i,m} s_{i,m}^T,
+```
+
+where `s_{i,m}` is the per-cell score evaluated at `M_i = m`.
+
+The category probabilities are `Pr(M_i = 0) = 1 − q_i p_{i1}` and
+`Pr(M_i = m) = q_i Δ_{i,m}` for `m ≥ 1`. Define
+
+```
+ν_{i,0} = q_i^2 u_{i1}^2 / (1 − q_i p_{i1})           (contribution from m = 0),
+ν_{i,k} = q_i / Δ_{i,k}                                (m = k contribution scale, k ≥ 1).
+```
+
+Under Option B the blocks of `I(θ)` are as follows.
+
+**α-block (tridiagonal in `t`).** For `t = 1`:
+
+```
+I_{α_1, α_1} = Σ_i [ q_i u_{i1}^2 / Δ_{i,1}  +  ν_{i,0} ].
+```
+
+For `2 ≤ t ≤ T`:
+
+```
+I_{α_t, α_t} = Σ_i [ q_i u_{it}^2 / Δ_{i,t}  +  q_i u_{it}^2 / Δ_{i,t−1} ].
+```
+
+Off-diagonal entries (only adjacent `t` couple, because score for `α_t`
+is non-zero only when `m_i ∈ {t − 1, t}`):
+
+```
+I_{α_t, α_{t+1}} = − Σ_i q_i u_{it} u_{i,t+1} / Δ_{i,t}    for t = 1, ..., T − 1,
+I_{α_t, α_s}     = 0    for |t − s| ≥ 2.
+```
+
+The `m_i = 0` mass enters `I_{α_1, α_1}` via `ν_{i,0}` and nowhere else,
+because `∂ℓ_i/∂α_t = 0` at `m_i = 0` for `t ≥ 2`.
+
+**β-block:**
+
+```
+I_{β, β} = Σ_i x_i x_i^T · v_i,
+v_i = Σ_{k = 1}^{T} q_i D_{ik}^2 / Δ_{i,k}  +  ν_{i,0}.
+```
+
+**α–β cross-block.** For `t = 1`:
+
+```
+I_{α_1, β} = Σ_i x_i · [ q_i u_{i1} D_{i,1} / Δ_{i,1}  +  ν_{i,0} ].
+```
+
+For `2 ≤ t ≤ T`:
+
+```
+I_{α_t, β} = Σ_i x_i · [ q_i u_{it} D_{i,t} / Δ_{i,t}
+                       − q_i u_{it} D_{i,t−1} / Δ_{i,t−1} ].
+```
+
+(Sign comes from `∂ℓ_i/∂α_t |_{m_i = t − 1} = − u_{it}/Δ_{i,t−1}`.)
+
+**Reduction at `T = 1`.** Then `Δ_{i,1} = p_{i1}`, `D_{i,1} = u_{i1}`, the
+α-block is a scalar `α_1`, and
+
+```
+I_{β, β} |_{T = 1}
+   = Σ_i x_i x_i^T · [ q_i u_{i1}^2 / p_{i1}  +  q_i^2 u_{i1}^2 / (1 − q_i p_{i1}) ]
+   = Σ_i x_i x_i^T · q_i u_{i1}^2 · [ 1 / p_{i1} + q_i / (1 − q_i p_{i1}) ].
+```
+
+Combine the bracket as `[ (1 − q_i p_{i1}) + q_i p_{i1} ] / [ p_{i1} (1 − q_i p_{i1}) ]
+= 1 / [ p_{i1} (1 − q_i p_{i1}) ]`, and substitute `u_{i1}^2 = p_{i1}^2 (1 − p_{i1})^2`, giving
+
+```
+I_{β, β} |_{T = 1} = Σ_i x_i x_i^T · q_i p_{i1} (1 − p_{i1})^2 / (1 − q_i p_{i1}),
+```
+
+which matches `wii = q_i p_i (1 − p_i)^2 / (1 − q_i p_i)` in `infor_mat`
+exactly.
+
+### 5.2 Observed information under Option A (Louis identity)
+
+For Option A we use Louis' identity to avoid expanding the
+mixture-derivative algebra. Louis gives the *observed* information:
+
+```
+J_i^{obs}(θ) = E_{γ_i}[ J_i^{complete}(θ) ]
+             − E_{γ_i}[ S_i^{complete}(θ) S_i^{complete}(θ)^T ]
+             + S_i(θ) S_i(θ)^T,
+```
+
+where the "complete-data" score and information `S^{complete}, J^{complete}`
+are the standard cumulative-logit quantities for the latent `Y_i`
+(McCullagh, 1980), and the expectations are taken under the latent-class
+posterior `γ_{ik}` from §3.2. Summed over `i` this gives the observed
+information `J^{obs}(θ)`.
+
+For the Firth penalty in §6 we use `J^{obs}(θ̂)` evaluated at the current
+iterate. This is consistent with Heinze & Schemper's recommendation and
+with the existing binary code, which also evaluates `infor_mat` at the
+current iterate rather than taking an outer expectation over `M`.
+
+Computing the *expected* Fisher information under Option A would require
+an additional outer expectation over `M_i` and is not needed for the
+implementation.
+
+## 6. Firth penalty
+
+Carry over the existing penalisation. The penalised log-likelihood is
+
+```
+ℓ*(θ) = ℓ(θ) + (1/2) log det I(θ),
+```
+
+with `I(θ)` the expected Fisher information from §5.1 under Option B, or
+the observed information `J^{obs}(θ)` from §5.2 under Option A. The
+penalty score is
+
+```
+∂ℓ*/∂θ_r = ∂ℓ/∂θ_r + (1/2) tr( I^{-1} ∂I/∂θ_r ),
+```
+
+which generalises `loss_grad_pen`. Because `I(θ)` now mixes `α` and `β`
+through a non-trivial cross-block, we cannot factor the working weights
+through a single `sqrt(W) · X` matrix as in the binary case. The cleanest
+implementation is to assemble `I(θ)` block-by-block from §5.1 and apply the
+matrix-derivative identity directly; the Cholesky of `I` can be reused for
+both the IRLS step and the Firth gradient.
+
+## 7. Order-constraint / identifiability
+
+`α_1 ≥ α_2 ≥ ... ≥ α_T` is required for valid probabilities. We
+reparameterise as
+
+```
+α_1 = ã_1,
+α_t = ã_1 − Σ_{s = 2}^{t} exp(ã_s),    t = 2, ..., T,
+```
+
+so `ã ∈ R^T` is unconstrained and `α_{t−1} − α_t = exp(ã_t) > 0` for
+`t ≥ 2`, which strictly enforces the ordering.
+
+Score and Hessian transform via the Jacobian `J = ∂α/∂ã`, which is
+lower-triangular with column 1 of all ones, `J_{t,s} = − exp(ã_s)` for
+`2 ≤ s ≤ t`, and zero above the diagonal:
+
+```
+score_ã = J^T · score_α,
+H_ã     = J^T · H_α · J  +  Σ_t (∂J/∂ã)_t · score_α[t]    (Newton),
+```
+
+with `(∂²α_t/∂ã_s ∂ã_s) = − exp(ã_s)` along the diagonal of the curvature
+correction. The correction vanishes at the optimum and can be dropped for
+Fisher scoring.
+
+Initial values: warm-start with `β = 0`, set `α̂_t` by inverting the
+empirical cumulative rate after capture correction, then map back to `ã`:
+
+```
+α̂_t = logit( clip( mean_i 1[m_i ≥ t] / mean_i q_i,  ε,  1 − ε ) ),
+ã_1 = α̂_1,
+ã_t = log( max( ε,  α̂_{t−1} − α̂_t ) )    for t = 2, ..., T.
+```
+
+This matches the spirit of the existing `par_initial = 0.05` warm start when
+`T = 1`.
+
+## 8. Reduction to the binary model
+
+When `T = 1`:
+
+- Option A and Option B coincide. (At `T = 1`, the only Binomial mixture
+  weights are `w_{i,1} = q_i` for `m = 1` and `w_{i,0} = 1 − q_i p_{i1}`
+  marginal mass at `m = 0`, recovering the Bernoulli model.)
+- The α-block is a scalar `α_1`; concatenating `(α_1, β)` gives the
+  existing PACS design `θ = (intercept, β)`.
+- The score in §4.1 reduces to `loss_gradient` term-for-term (verified
+  above for both `m = 0` and `m = 1`).
+- The Fisher information in §5.1 reduces to `infor_mat` (verified by the
+  algebra at the end of §5.1: `q_i p_{i1} (1 − p_{i1})^2 / (1 − q_i p_{i1})`).
+- The Firth penalty in §6 reduces to `loss_grad_pen`.
+
+This gives us a precise parity test to validate the implementation.
+
+## 9. Likelihood-ratio test under the new model
+
+`compare_models` in `R/differential_identification.R` currently computes the
+penalised LRT using the binary working weights even when called from the
+cumulative wrapper. After the change, the full and null models are fit with
+the cumulative likelihood from §3, and the Firth-corrected LRT uses
+
+```
+2 [ ℓ*_full(θ̂_full) − ℓ*_null(θ̂_null) ]   ~   χ²_{df},
+```
+
+with `df` equal to the number of `β` components constrained to zero under
+the null. Both models re-estimate all `α_t` from the same `T`-dimensional
+threshold space, so the thresholds contribute zero to the df.
+
+**Boundary caveat.** The χ² approximation assumes the MLE is interior to
+the feasible region. When the order constraint `α_1 ≥ ... ≥ α_T` is
+active at the optimum (i.e. some `exp(ã_t)` is at the lower clip), the
+parameter is on the boundary and the LRT follows a mixture of χ²
+distributions per Self–Liang. In practice we should flag fits that hit the
+clip and either widen the clip or report a warning rather than a p-value.
+
+## 10. Implementation plan
+
+Phased rollout to keep the existing pipeline working:
+
+1. **Phase 1 (Option B, parity).** Add `R/param_estimate_cumu.R` with
+   `loss_fun_cumu`, `loss_gradient_cumu`, `infor_mat_cumu`,
+   `loss_grad_pen_cumu`, `irls_iter_cumu`, `irls_iter_cumu_null`. At `T = 1`
+   these must match the existing binary functions to machine precision; add a
+   test in `tests/testthat` that exercises this parity.
+2. **Phase 1 wiring.** Add `method = c("exact", "stacked")` to
+   `pacs_test_cumu`. Default remains `"stacked"` for back-compat in this PR.
+   Provide a vignette example comparing the two on simulated `T = 2` data.
+3. **Phase 2 (LRT).** Update `compare_models` (or add
+   `compare_models_cumu`) to compute the penalised LRT with the new
+   information matrix, used when `method = "exact"`.
+4. **Phase 3 (Option A).** Add a thinning-mode flag and the Louis-identity
+   information matrix. Validate against Phase 1 by simulating from each
+   model and confirming approximate parity at `q_i ≈ 1`.
+5. **Phase 4 (default switch).** Once Phases 1–3 are validated, switch
+   `pacs_test_cumu`'s default to `method = "exact"` and deprecate the
+   stacking path.
+
+Out of scope for this PR: any changes to the binary `pacs_test_logit`
+pipeline.

--- a/tests/testthat/helper-cumu.R
+++ b/tests/testthat/helper-cumu.R
@@ -1,0 +1,24 @@
+## Shared fixtures for cumulative-logit tests.
+
+## Default seed-controlled fixture: n cells, p covariates, T thresholds,
+## known (alpha, beta), capture rates uniformly in [q_lo, q_hi].
+make_cumu_fixture <- function(n = 400L, p = 2L, T = 2L,
+                              alpha = c(0.8, -0.4),
+                              beta = c(0.6, -0.3),
+                              q_lo = 0.4, q_hi = 0.9, seed = 1L) {
+  set.seed(seed)
+  X <- matrix(rnorm(n * p), nrow = n, ncol = p)
+  colnames(X) <- paste0("x", seq_len(p))
+  q <- runif(n, q_lo, q_hi)
+  list(X = X, q = q, alpha = alpha[seq_len(T)], beta = beta[seq_len(p)],
+       T = T, n = n, p = p)
+}
+
+## Build (alpha_1, beta) -> theta-binary equivalent vector for parity tests.
+binary_theta_from_cumu <- function(theta_cumu, T) {
+  ## In the cumu code at T=1, theta = (atilde_1 = alpha_1, beta...).
+  ## In binary code, theta = (intercept, beta...) with X having an intercept
+  ## column. So they map directly: binary_theta = theta_cumu.
+  stopifnot(T == 1L)
+  theta_cumu
+}

--- a/tests/testthat/test-cumu-LRT.R
+++ b/tests/testthat/test-cumu-LRT.R
@@ -1,0 +1,63 @@
+## Under the null (true beta_test = 0), the cumulative-logit LRT p-values
+## from compare_models_cumu should be approximately uniform.
+
+test_that("LRT p-values are roughly uniform under the null", {
+  skip_on_cran()
+  n_rep <- 100L
+  n <- 300L
+  alpha <- c(0.7, -0.3)
+  beta_full <- c(0.4, 0.0)  ## second covariate is the test target; set to 0
+  pvals <- numeric(n_rep)
+  ok <- logical(n_rep)
+
+  for (r in seq_len(n_rep)) {
+    fx <- make_cumu_fixture(n = n, p = 2L, T = 2L,
+                            alpha = alpha, beta = beta_full,
+                            seed = 1000L + r)
+    M <- PACS:::simulate_cumu_pacs(X = fx$X, alpha = fx$alpha, beta = fx$beta,
+                                   q = fx$q, capture = "B", seed = 1500L + r)
+
+    ## Full fit: both betas free.
+    th_init <- PACS:::warm_start_theta(M = M, q = fx$q, T = 2L, p_beta = 2L)
+    res_full <- PACS:::irls_iter_cumu(M_vec = M, X = fx$X,
+                                      theta_estimated = th_init,
+                                      q_vec = fx$q, T = 2L)
+    ## Null fit: beta_2 (last entry) held at 0.
+    th_init_null <- th_init
+    th_init_null[4L] <- 0
+    res_null <- PACS:::irls_iter_cumu_null(M_vec = M, X = fx$X,
+                                           theta_estimated = th_init_null,
+                                           hold_zero = 4L,
+                                           q_vec = fx$q, T = 2L)
+
+    if (res_full[length(res_full)] != 1L || res_null[length(res_null)] != 1L) {
+      next
+    }
+
+    th_full <- res_full[seq_len(length(res_full) - 1L)]
+    th_null <- res_null[seq_len(length(res_null) - 1L)]
+
+    pv <- PACS:::compare_models_cumu(
+      x_full = fx$X,
+      theta_estimated_full = matrix(th_full, ncol = 1L),
+      theta_estimated_null = matrix(th_null, ncol = 1L),
+      q_vec = fx$q,
+      c_by_r = matrix(M, ncol = 1L),
+      T = 2L, df_test = 1L, mc.cores = 1L
+    )
+    if (is.finite(pv) && pv >= 0 && pv <= 1) {
+      pvals[r] <- pv
+      ok[r] <- TRUE
+    }
+  }
+
+  pv_ok <- pvals[ok]
+  expect_gt(length(pv_ok), 0.7 * n_rep)  ## most replicates produced a p-value
+
+  ## Kolmogorov-Smirnov test for uniformity. Allow some slack: if KS p > 0.01
+  ## we consider the calibration acceptable for this small simulation.
+  ks_p <- suppressWarnings(stats::ks.test(pv_ok, "punif")$p.value)
+  message(sprintf("LRT calibration: n=%d valid p-values, KS p=%.3f",
+                  length(pv_ok), ks_p))
+  expect_gt(ks_p, 0.01)
+})

--- a/tests/testthat/test-cumu-T1-parity.R
+++ b/tests/testthat/test-cumu-T1-parity.R
@@ -1,0 +1,84 @@
+## At T = 1, the cumulative-logit functions in R/param_estimate_cumu.R must
+## reduce term-for-term to the binary functions in
+## R/param-estimate_logit_get_p_by_t_June.R. Math note §8.
+
+test_that("loss_fun_cumu agrees with loss_fun at T=1", {
+  fx <- make_cumu_fixture(n = 50L, p = 2L, T = 1L,
+                          alpha = 0.7, beta = c(0.5, -0.2), seed = 11L)
+  M <- PACS:::simulate_cumu_pacs(X = fx$X, alpha = fx$alpha, beta = fx$beta,
+                                 q = fx$q, capture = "B", seed = 12L)
+
+  ## Build binary theta (intercept = alpha_1) and X_bin = cbind(1, X).
+  theta_cumu <- c(fx$alpha, fx$beta)
+  theta_bin <- theta_cumu
+  X_bin <- cbind(intercept = 1, fx$X)
+  p_bg <- 1 / (1 + exp(-as.numeric(X_bin %*% theta_bin)))
+
+  ll_cumu <- PACS:::loss_fun_cumu(theta = theta_cumu, X = fx$X, M = M,
+                                  q = fx$q, T = 1L)
+  ll_bin <- loss_fun(p_bg = p_bg, q_vec = fx$q, y_vec = M)
+
+  ## Cumu drops the constant log q_i for m >= 1; binary keeps it.
+  expect_equal(ll_cumu, ll_bin - sum(log(fx$q[M == 1L])), tolerance = 1e-10)
+})
+
+
+test_that("loss_gradient_cumu agrees with loss_gradient at T=1", {
+  fx <- make_cumu_fixture(n = 50L, p = 2L, T = 1L,
+                          alpha = 0.5, beta = c(0.4, -0.3), seed = 21L)
+  M <- PACS:::simulate_cumu_pacs(X = fx$X, alpha = fx$alpha, beta = fx$beta,
+                                 q = fx$q, capture = "B", seed = 22L)
+  theta_cumu <- c(fx$alpha, fx$beta)
+  X_bin <- cbind(intercept = 1, fx$X)
+  p_bg <- 1 / (1 + exp(-as.numeric(X_bin %*% theta_cumu)))
+
+  g_cumu <- PACS:::loss_gradient_cumu(theta = theta_cumu, X = fx$X, M = M,
+                                      q = fx$q, T = 1L)
+  g_bin <- loss_gradient(xdumm = X_bin, p_bg = p_bg, q_vec = fx$q, y_vec = M)
+  expect_equal(as.numeric(g_cumu), as.numeric(g_bin), tolerance = 1e-10)
+})
+
+
+test_that("infor_mat_cumu agrees with infor_mat at T=1", {
+  fx <- make_cumu_fixture(n = 50L, p = 2L, T = 1L,
+                          alpha = 0.3, beta = c(0.2, 0.1), seed = 31L)
+  theta_cumu <- c(fx$alpha, fx$beta)
+  X_bin <- cbind(intercept = 1, fx$X)
+  p_bg <- 1 / (1 + exp(-as.numeric(X_bin %*% theta_cumu)))
+
+  I_cumu <- PACS:::infor_mat_cumu(theta = theta_cumu, X = fx$X, q = fx$q, T = 1L)
+  I_bin <- infor_mat(xdumm = X_bin, p_bg = p_bg, q_vec = fx$q)
+  expect_equal(as.numeric(I_cumu), as.numeric(I_bin), tolerance = 1e-10)
+})
+
+
+test_that("irls_iter_cumu and irls_iter agree at T=1", {
+  fx <- make_cumu_fixture(n = 200L, p = 2L, T = 1L,
+                          alpha = 0.4, beta = c(0.5, -0.4), seed = 41L)
+  M <- PACS:::simulate_cumu_pacs(X = fx$X, alpha = fx$alpha, beta = fx$beta,
+                                 q = fx$q, capture = "B", seed = 42L)
+
+  theta_init <- rep.int(0.05, 1L + ncol(fx$X))
+  X_bin <- cbind(intercept = 1, fx$X)
+
+  res_cumu <- PACS:::irls_iter_cumu(M_vec = M, X = fx$X,
+                                    theta_estimated = theta_init,
+                                    q_vec = fx$q, T = 1L)
+  res_bin <- irls_iter(y_vec = M, xdumm = X_bin,
+                       theta_estimated = theta_init,
+                       q_vec = fx$q)
+
+  conv_cumu <- res_cumu[length(res_cumu)]
+  conv_bin <- res_bin[length(res_bin)]
+  expect_true(conv_cumu == 1L,
+              info = paste("cumu convergence flag:", conv_cumu))
+  expect_true(conv_bin == 1L,
+              info = paste("bin convergence flag:", conv_bin))
+
+  th_cumu <- res_cumu[seq_len(length(res_cumu) - 1L)]
+  th_bin <- res_bin[seq_len(length(res_bin) - 1L)]
+  ## Tolerance loosened from 1e-6 to 1e-4: cumu uses FD on the Firth penalty
+  ## derivative (loss_grad_pen_cumu), binary uses an analytic form. Both are
+  ## valid optima of the same objective and should agree at FD precision.
+  expect_equal(th_cumu, th_bin, tolerance = 1e-4)
+})

--- a/tests/testthat/test-cumu-T2-recovery.R
+++ b/tests/testthat/test-cumu-T2-recovery.R
@@ -1,0 +1,45 @@
+## T=2 parameter recovery: simulate from known (alpha, beta) under Option B,
+## fit, and assert MLE within tolerance of truth across replicates.
+##
+## Soft assertions (expect_lt) are used so flakiness is bounded; thresholds
+## are sized for the n=400, 30-replicate setup below.
+
+test_that("MLE recovers alpha and beta at T=2", {
+  skip_on_cran()
+  n_rep <- 30L
+  n <- 400L
+  alpha <- c(0.8, -0.4)
+  beta <- c(0.6, -0.3)
+
+  alpha_hat <- matrix(NA_real_, nrow = n_rep, ncol = 2L)
+  beta_hat <- matrix(NA_real_, nrow = n_rep, ncol = 2L)
+  conv <- integer(n_rep)
+
+  for (r in seq_len(n_rep)) {
+    fx <- make_cumu_fixture(n = n, p = 2L, T = 2L,
+                            alpha = alpha, beta = beta, seed = 100L + r)
+    M <- PACS:::simulate_cumu_pacs(X = fx$X, alpha = fx$alpha, beta = fx$beta,
+                            q = fx$q, capture = "B", seed = 200L + r)
+    theta_init <- PACS:::warm_start_theta(M = M, q = fx$q, T = 2L, p_beta = 2L)
+    res <- PACS:::irls_iter_cumu(M_vec = M, X = fx$X,
+                                 theta_estimated = theta_init,
+                                 q_vec = fx$q, T = 2L)
+    conv[r] <- res[length(res)]
+    th <- res[seq_len(length(res) - 1L)]
+    if (conv[r] == 1L) {
+      ## Map atilde back to alpha for comparison.
+      alpha_hat[r, ] <- PACS:::alpha_from_atilde(th[1:2])
+      beta_hat[r, ] <- th[3:4]
+    }
+  }
+
+  ok <- conv == 1L
+  expect_gt(mean(ok), 0.85)  ## convergence rate
+
+  bias_alpha <- colMeans(alpha_hat[ok, , drop = FALSE]) - alpha
+  bias_beta <- colMeans(beta_hat[ok, , drop = FALSE]) - beta
+
+  ## Mean absolute bias should be small with n=400 and 30 replicates.
+  expect_lt(max(abs(bias_alpha)), 0.15)
+  expect_lt(max(abs(bias_beta)), 0.15)
+})

--- a/tests/testthat/test-cumu-T2-stacked-vs-exact.R
+++ b/tests/testthat/test-cumu-T2-stacked-vs-exact.R
@@ -1,0 +1,61 @@
+## Informational test: at T=2 on simulated data, the exact path should
+## produce lower mean squared error on beta than the stacked approximation.
+##
+## This is a sanity check, not a strict assertion of any specific magnitude:
+## the stacked approach has provable bias because it treats nested
+## indicators as independent Bernoulli, double-counting each cell.
+
+test_that("exact has no worse bias than stacked at T=2", {
+  skip_on_cran()
+  n_rep <- 20L
+  n <- 400L
+  alpha <- c(0.8, -0.4)
+  beta <- c(0.6, -0.3)
+
+  beta_hat_exact <- matrix(NA_real_, nrow = n_rep, ncol = 2L)
+  beta_hat_stack <- matrix(NA_real_, nrow = n_rep, ncol = 2L)
+
+  for (r in seq_len(n_rep)) {
+    fx <- make_cumu_fixture(n = n, p = 2L, T = 2L,
+                            alpha = alpha, beta = beta, seed = 700L + r)
+    M <- PACS:::simulate_cumu_pacs(X = fx$X, alpha = fx$alpha, beta = fx$beta,
+                            q = fx$q, capture = "B", seed = 800L + r)
+
+    ## Exact fit.
+    theta_init <- PACS:::warm_start_theta(M = M, q = fx$q, T = 2L, p_beta = 2L)
+    res_exact <- PACS:::irls_iter_cumu(M_vec = M, X = fx$X,
+                                       theta_estimated = theta_init,
+                                       q_vec = fx$q, T = 2L)
+    if (res_exact[length(res_exact)] == 1L) {
+      beta_hat_exact[r, ] <- res_exact[3:4]
+    }
+
+    ## Stacked fit via the existing binary IRLS on stacked data.
+    Z1 <- as.integer(M >= 1L)
+    Z2 <- as.integer(M >= 2L)
+    A <- diag(2L)
+    X_alpha <- A[c(rep(1L, n), rep(2L, n)), , drop = FALSE]
+    X_stack <- cbind(X_alpha, rbind(fx$X, fx$X))
+    q_stack <- c(fx$q, fx$q)
+    Z_stack <- c(Z1, Z2)
+    theta_init_stack <- rep.int(0.05, ncol(X_stack))
+    res_stack <- irls_iter(y_vec = Z_stack, xdumm = X_stack,
+                           theta_estimated = theta_init_stack,
+                           q_vec = q_stack)
+    if (res_stack[length(res_stack)] == 1L) {
+      ## Last 2 entries are beta in our stacked design.
+      beta_hat_stack[r, ] <- res_stack[3:4]
+    }
+  }
+
+  ## Compute MSE per coordinate, summed.
+  mse <- function(B, true) mean(rowSums((B - matrix(true, nrow = nrow(B),
+                                                    ncol = length(true),
+                                                    byrow = TRUE))^2,
+                                        na.rm = TRUE), na.rm = TRUE)
+  mse_exact <- mse(beta_hat_exact, beta)
+  mse_stack <- mse(beta_hat_stack, beta)
+
+  message(sprintf("MSE(beta) exact = %.4f, stacked = %.4f", mse_exact, mse_stack))
+  expect_lte(mse_exact, mse_stack * 1.10)  ## exact within 10% of stacked or better
+})

--- a/tests/testthat/test-cumu-api-smoke.R
+++ b/tests/testthat/test-cumu-api-smoke.R
@@ -1,0 +1,191 @@
+## End-to-end smoke test for pacs_test_cumu(method = "exact").
+## Verifies the public API wiring: formula parsing, intercept stripping,
+## parameter-of-interest identification, warm start, fitting, and LRT
+## all work together correctly.
+
+test_that("pacs_test_cumu exact returns correct structure", {
+  set.seed(99L)
+  n <- 200L
+  n_peaks <- 5L
+  T <- 2L
+  alpha <- c(0.6, -0.3)
+  beta <- 0.5
+
+  group <- factor(c(rep("A", n %/% 2), rep("B", n - n %/% 2)))
+  X_raw <- model.matrix(~ group)[, -1, drop = FALSE]
+  q <- runif(n, 0.4, 0.9)
+
+  ## Simulate a small pic_matrix (peaks x cells) with count values in 0..T.
+  pic <- matrix(0L, nrow = n_peaks, ncol = n)
+  rownames(pic) <- paste0("peak", seq_len(n_peaks))
+  for (j in seq_len(n_peaks)) {
+    pic[j, ] <- PACS:::simulate_cumu_pacs(
+      X = X_raw, alpha = alpha, beta = beta,
+      q = q, capture = "B", seed = 900L + j
+    )
+  }
+
+  meta <- data.frame(group = group)
+
+  result <- pacs_test_cumu(
+    covariate_meta.data = meta,
+    formula_full = ~ group,
+    formula_null = ~ 1,
+    pic_matrix = pic,
+    max_T = T,
+    cap_rates = q,
+    n_cores = 1L,
+    method = "exact"
+  )
+
+  ## --- Structure checks ---
+  expect_type(result, "list")
+  expect_named(result, c("pacs_converged", "pacs_p_val"))
+  expect_length(result$pacs_p_val, n_peaks)
+  expect_true(all(names(result$pacs_p_val) == rownames(pic)))
+
+  ## p-values should be in [0, 1]
+  expect_true(all(result$pacs_p_val >= 0 & result$pacs_p_val <= 1,
+                  na.rm = TRUE))
+
+  ## Convergence vector: 2 * n_peaks (null + full)
+  expect_length(result$pacs_converged, 2L * n_peaks)
+
+  message(sprintf("API smoke: %d peaks, p-values = [%s]",
+                  n_peaks,
+                  paste(sprintf("%.4f", result$pacs_p_val), collapse = ", ")))
+})
+
+
+test_that("pacs_test_cumu exact matches internal functions", {
+  skip_on_cran()
+  set.seed(55L)
+  n <- 150L
+  n_peaks <- 3L
+  T <- 2L
+  alpha <- c(0.7, -0.4)
+  beta <- 0.3
+
+  group <- factor(c(rep("ctrl", n %/% 2), rep("treat", n - n %/% 2)))
+  X_raw <- model.matrix(~ group)[, -1, drop = FALSE]
+  colnames(X_raw) <- "grouptreat"
+  q <- runif(n, 0.5, 0.8)
+
+  pic <- matrix(0L, nrow = n_peaks, ncol = n)
+  rownames(pic) <- paste0("peak", seq_len(n_peaks))
+  for (j in seq_len(n_peaks)) {
+    pic[j, ] <- PACS:::simulate_cumu_pacs(
+      X = X_raw, alpha = alpha, beta = beta,
+      q = q, capture = "B", seed = 1100L + j
+    )
+  }
+
+  meta <- data.frame(group = group)
+
+  ## Public API
+  res_api <- pacs_test_cumu(
+    covariate_meta.data = meta,
+    formula_full = ~ group,
+    formula_null = ~ 1,
+    pic_matrix = pic,
+    max_T = T,
+    cap_rates = q,
+    n_cores = 1L,
+    method = "exact"
+  )
+
+  ## Internal path: fit each peak manually
+  pv_manual <- numeric(n_peaks)
+  for (j in seq_len(n_peaks)) {
+    M_j <- pic[j, ]
+    th_init <- PACS:::warm_start_theta(M = M_j, q = q, T = T, p_beta = 1L)
+    res_full <- PACS:::irls_iter_cumu(
+      M_vec = M_j, X = X_raw, theta_estimated = th_init, q_vec = q, T = T
+    )
+    th_init_null <- th_init
+    th_init_null[3L] <- 0
+    res_null <- PACS:::irls_iter_cumu_null(
+      M_vec = M_j, X = X_raw, theta_estimated = th_init_null,
+      hold_zero = 3L, q_vec = q, T = T
+    )
+    if (res_full[length(res_full)] == 1L &&
+        res_null[length(res_null)] == 1L) {
+      th_f <- res_full[1:3]
+      th_n <- res_null[1:3]
+      pv_manual[j] <- PACS:::compare_models_cumu(
+        x_full = X_raw,
+        theta_estimated_full = matrix(th_f, ncol = 1L),
+        theta_estimated_null = matrix(th_n, ncol = 1L),
+        q_vec = q, c_by_r = matrix(M_j, ncol = 1L),
+        T = T, df_test = 1L, mc.cores = 1L
+      )
+    } else {
+      pv_manual[j] <- NA_real_
+    }
+  }
+
+  ## The public API pools all peaks for a shared warm start, so estimates
+  ## can differ slightly. But p-values should be close when both converge.
+  both_finite <- is.finite(pv_manual) & is.finite(res_api$pacs_p_val)
+  expect_gt(sum(both_finite), 0)
+
+  ## Log the comparison rather than assert exact equality (warm-start
+  ## differences can propagate), but check they're in the same ballpark.
+  for (j in which(both_finite)) {
+    message(sprintf("peak%d: API p=%.4f, manual p=%.4f",
+                    j, res_api$pacs_p_val[j], pv_manual[j]))
+  }
+
+  ## Both should agree on which peaks are significant at a liberal threshold.
+  sig_api <- unname(res_api$pacs_p_val[both_finite] < 0.10)
+  sig_manual <- unname(pv_manual[both_finite] < 0.10)
+  expect_equal(sig_api, sig_manual,
+               label = "API and manual agree on significance calls")
+})
+
+
+test_that("pacs_test_cumu exact handles multiple covariates", {
+  set.seed(33L)
+  n <- 200L
+  n_peaks <- 3L
+  T <- 2L
+
+  group <- factor(c(rep("A", n %/% 2), rep("B", n - n %/% 2)))
+  batch <- rnorm(n)
+  meta <- data.frame(group = group, batch = batch)
+
+  X_full <- model.matrix(~ group + batch, data = meta)
+  X_raw <- X_full[, -1, drop = FALSE]
+  q <- runif(n, 0.5, 0.8)
+
+  ## Simulate with group effect, no batch effect
+  alpha <- c(0.6, -0.3)
+  beta <- c(0.4, 0.0)  ## groupB effect, no batch effect
+  pic <- matrix(0L, nrow = n_peaks, ncol = n)
+  rownames(pic) <- paste0("peak", seq_len(n_peaks))
+  for (j in seq_len(n_peaks)) {
+    pic[j, ] <- PACS:::simulate_cumu_pacs(
+      X = X_raw, alpha = alpha, beta = beta,
+      q = q, capture = "B", seed = 1200L + j
+    )
+  }
+
+  ## Test group effect adjusting for batch
+  result <- pacs_test_cumu(
+    covariate_meta.data = meta,
+    formula_full = ~ group + batch,
+    formula_null = ~ batch,
+    pic_matrix = pic,
+    max_T = T,
+    cap_rates = q,
+    n_cores = 1L,
+    method = "exact"
+  )
+
+  expect_length(result$pacs_p_val, n_peaks)
+  expect_true(all(result$pacs_p_val >= 0 & result$pacs_p_val <= 1,
+                  na.rm = TRUE))
+
+  message(sprintf("Multi-covariate: p-values = [%s]",
+                  paste(sprintf("%.4f", result$pacs_p_val), collapse = ", ")))
+})

--- a/tests/testthat/test-cumu-capture-rate-confounding.R
+++ b/tests/testthat/test-cumu-capture-rate-confounding.R
@@ -1,0 +1,164 @@
+## When two groups have different capture rates but identical accessibility
+## (beta_group = 0), clm() — which has no capture-rate model — confounds
+## "captured more" with "more accessible" and produces a spurious group
+## effect. PACS corrects for this via the q_i layer.
+##
+## Test design: vary (q_A, q_B) from equal to highly divergent. At each
+## combination, simulate n_rep replicates under the null and measure:
+##   1. Mean |beta_group| estimate (bias)
+##   2. Rejection rate at nominal 5%
+##
+## Expected trends:
+##   - PACS: beta_group ≈ 0 and rejection ≈ 5% regardless of q gap
+##   - clm:  bias and rejection grow monotonically with |q_A - q_B|
+##   - At equal q: PACS ≈ clm (both correct)
+
+test_that("PACS stays calibrated while clm() degrades as capture-rate gap widens", {
+  skip_on_cran()
+  skip_if_not_installed("ordinal")
+
+  n <- 400L
+  T <- 2L
+  alpha_true <- c(0.7, -0.3)
+  beta_group_true <- 0.0  ## null: no accessibility difference
+  n_rep <- 80L
+  nominal_alpha <- 0.05
+
+  ## Capture-rate scenarios: (q_groupA, q_groupB), ordered by increasing gap.
+  scenarios <- list(
+    c(0.70, 0.70),
+    c(0.60, 0.80),
+    c(0.50, 0.80),
+    c(0.40, 0.80),
+    c(0.30, 0.80)
+  )
+
+  rej_pacs <- numeric(length(scenarios))
+  rej_clm <- numeric(length(scenarios))
+  bias_pacs <- numeric(length(scenarios))
+  bias_clm <- numeric(length(scenarios))
+
+  for (s in seq_along(scenarios)) {
+    q_A <- scenarios[[s]][1]
+    q_B <- scenarios[[s]][2]
+
+    pv_pacs <- numeric(n_rep)
+    pv_clm <- numeric(n_rep)
+    beta_hat_pacs <- numeric(n_rep)
+    beta_hat_clm <- numeric(n_rep)
+    ok_pacs <- logical(n_rep)
+    ok_clm <- logical(n_rep)
+
+    for (r in seq_len(n_rep)) {
+      set.seed(5000L + r + s * 1000L)
+      n_A <- n %/% 2L
+      n_B <- n - n_A
+
+      ## Group indicator (the covariate of interest)
+      group <- c(rep(0L, n_A), rep(1L, n_B))
+      X <- matrix(group, ncol = 1L)
+      colnames(X) <- "group"
+
+      ## Per-cell capture rates
+      q <- c(rep(q_A, n_A), rep(q_B, n_B))
+
+      ## Simulate under null: same alpha for both groups, beta_group = 0
+      M <- PACS:::simulate_cumu_pacs(
+        X = X, alpha = alpha_true,
+        beta = beta_group_true,
+        q = q, capture = "B", seed = 6000L + r + s * 1000L
+      )
+
+      ## ---- PACS exact cumulative-logit (knows about q) ----
+      th_init <- PACS:::warm_start_theta(M = M, q = q, T = T, p_beta = 1L)
+      res_full <- PACS:::irls_iter_cumu(
+        M_vec = M, X = X, theta_estimated = th_init, q_vec = q, T = T
+      )
+      th_init_null <- th_init
+      th_init_null[3L] <- 0
+      res_null <- PACS:::irls_iter_cumu_null(
+        M_vec = M, X = X, theta_estimated = th_init_null,
+        hold_zero = 3L, q_vec = q, T = T
+      )
+      if (res_full[length(res_full)] == 1L &&
+          res_null[length(res_null)] == 1L) {
+        th_f <- res_full[1:3]
+        th_n <- res_null[1:3]
+        beta_hat_pacs[r] <- th_f[3L]
+        pv <- PACS:::compare_models_cumu(
+          x_full = X,
+          theta_estimated_full = matrix(th_f, ncol = 1L),
+          theta_estimated_null = matrix(th_n, ncol = 1L),
+          q_vec = q, c_by_r = matrix(M, ncol = 1L),
+          T = T, df_test = 1L, mc.cores = 1L
+        )
+        if (is.finite(pv) && pv >= 0 && pv <= 1) {
+          pv_pacs[r] <- pv
+          ok_pacs[r] <- TRUE
+        }
+      }
+
+      ## ---- ordinal::clm() (ignores capture rate) ----
+      Y_factor <- factor(M, levels = 0:T, ordered = TRUE)
+      df <- data.frame(Y = Y_factor, group = group)
+      fit <- try(ordinal::clm(Y ~ group, data = df, link = "logit"),
+                 silent = TRUE)
+      if (!inherits(fit, "try-error") && fit$convergence$code == 0L) {
+        beta_hat_clm[r] <- as.numeric(fit$beta)
+        ## Wald test p-value from clm summary
+        s_fit <- summary(fit)
+        pv_clm[r] <- s_fit$coefficients["group", "Pr(>|z|)"]
+        ok_clm[r] <- TRUE
+      }
+    }
+
+    both_ok <- ok_pacs & ok_clm
+    n_ok <- sum(both_ok)
+
+    rej_pacs[s] <- mean(pv_pacs[both_ok] < nominal_alpha)
+    rej_clm[s] <- mean(pv_clm[both_ok] < nominal_alpha)
+    bias_pacs[s] <- mean(abs(beta_hat_pacs[both_ok]))
+    bias_clm[s] <- mean(abs(beta_hat_clm[both_ok]))
+
+    message(sprintf(
+      "q=(%0.2f,%0.2f) gap=%.2f [%d reps]: rej PACS=%.3f clm=%.3f | mean|beta| PACS=%.4f clm=%.4f",
+      q_A, q_B, abs(q_A - q_B), n_ok,
+      rej_pacs[s], rej_clm[s], bias_pacs[s], bias_clm[s]
+    ))
+  }
+
+  ## ---- Assertions ----
+
+  ## 1. At equal capture rates (scenario 1), PACS and clm should be similar:
+  ##    both well-calibrated, both low bias.
+  expect_lt(rej_pacs[1], 0.15, label = "PACS rejection at equal q")
+  expect_lt(rej_clm[1], 0.15, label = "clm rejection at equal q")
+  expect_lt(abs(bias_pacs[1] - bias_clm[1]), 0.10,
+            label = "bias gap at equal q")
+
+  ## 2. PACS stays calibrated across all scenarios.
+  expect_lt(max(rej_pacs), 0.15,
+            label = "PACS rejection stays controlled")
+
+  ## 3. clm rejection rate at the widest gap should exceed PACS.
+  expect_gt(rej_clm[length(scenarios)], rej_pacs[length(scenarios)],
+            label = "clm rejects more than PACS at wide q gap")
+
+  ## 4. clm bias should increase monotonically with the gap (allow ties).
+  ##    Check that the widest-gap bias exceeds the equal-q bias.
+  expect_gt(bias_clm[length(scenarios)], bias_clm[1] + 0.01,
+            label = "clm bias grows with q gap")
+
+  ## 5. PACS bias should stay roughly flat (contrast: clm bias spans >1.0).
+  expect_lt(max(bias_pacs) - min(bias_pacs), 0.15,
+            label = "PACS bias stable across q gaps")
+
+  ## Print summary table for review.
+  message("\n--- Summary ---")
+  message("q_gap  | rej_PACS  rej_clm  | bias_PACS  bias_clm")
+  for (s in seq_along(scenarios)) {
+    message(sprintf("  %.2f |   %.3f    %.3f   |   %.4f    %.4f",
+                    abs(scenarios[[s]][1] - scenarios[[s]][2]),
+                    rej_pacs[s], rej_clm[s], bias_pacs[s], bias_clm[s]))
+  }
+})

--- a/tests/testthat/test-cumu-clm-parity.R
+++ b/tests/testthat/test-cumu-clm-parity.R
@@ -1,0 +1,202 @@
+## At q = 1 (no capture-rate layer), the cumulative-logit model reduces to
+## standard proportional-odds logistic regression. Validate against
+## ordinal::clm() which gives the unpenalized MLE.
+##
+## Two regimes:
+##   - Large n (n=2000): Firth correction is negligible, so our Firth-penalized
+##     estimates should nearly match clm().
+##   - Small n (n=80): Firth correction is non-negligible, so estimates differ,
+##     but our *unpenalized* log-likelihood evaluated at the clm() MLE should
+##     match clm()'s logLik exactly.
+
+test_that("at q=1 large n, Firth estimates match clm() closely", {
+  skip_on_cran()
+  skip_if_not_installed("ordinal")
+
+  set.seed(42L)
+  n <- 2000L
+  T <- 2L
+  p <- 2L
+  alpha <- c(0.8, -0.4)
+  beta <- c(0.6, -0.3)
+  X <- matrix(rnorm(n * p), nrow = n, ncol = p)
+  colnames(X) <- paste0("x", seq_len(p))
+  q <- rep(1.0, n)
+
+  M <- PACS:::simulate_cumu_pacs(X = X, alpha = alpha, beta = beta,
+                                 q = q, capture = "B", seed = 100L)
+
+  ## --- Our exact path (Firth-penalized IRLS) ---
+  theta_init <- PACS:::warm_start_theta(M = M, q = q, T = T, p_beta = p)
+  res <- PACS:::irls_iter_cumu(M_vec = M, X = X, theta_estimated = theta_init,
+                               q_vec = q, T = T)
+  expect_equal(res[length(res)], 1)  ## converged
+  th <- res[seq_len(length(res) - 1L)]
+  alpha_hat <- PACS:::alpha_from_atilde(th[1:T])
+  beta_hat <- th[(T + 1):(T + p)]
+
+  ## --- ordinal::clm() ---
+  Y_factor <- factor(M, levels = 0:T, ordered = TRUE)
+  df <- data.frame(Y = Y_factor, x1 = X[, 1], x2 = X[, 2])
+  fit_clm <- ordinal::clm(Y ~ x1 + x2, data = df, link = "logit")
+
+  ## clm() parameterises thresholds as α^clm_t = -α_t (opposite sign convention:
+  ## clm uses Pr(Y <= k) = σ(θ_k - x'β), we use Pr(Y >= t) = σ(α_t + x'β)).
+  alpha_clm <- -as.numeric(fit_clm$alpha)
+  beta_clm <- as.numeric(fit_clm$beta)
+
+  ## At n=2000, Firth shrinkage is O(1/n) ≈ 5e-4, so 0.05 tolerance is generous.
+  expect_equal(alpha_hat, alpha_clm, tolerance = 0.05,
+               label = "alpha vs clm at n=2000")
+  expect_equal(beta_hat, beta_clm, tolerance = 0.05,
+               label = "beta vs clm at n=2000")
+
+  message(sprintf("n=2000: alpha PACS=[%.4f, %.4f] clm=[%.4f, %.4f]",
+                  alpha_hat[1], alpha_hat[2], alpha_clm[1], alpha_clm[2]))
+  message(sprintf("n=2000: beta  PACS=[%.4f, %.4f] clm=[%.4f, %.4f]",
+                  beta_hat[1], beta_hat[2], beta_clm[1], beta_clm[2]))
+})
+
+
+test_that("at q=1 small n, unpenalized logLik matches clm() exactly", {
+  skip_on_cran()
+  skip_if_not_installed("ordinal")
+
+  set.seed(77L)
+  n <- 80L
+  T <- 2L
+  p <- 2L
+  alpha <- c(0.8, -0.4)
+  beta <- c(0.6, -0.3)
+  X <- matrix(rnorm(n * p), nrow = n, ncol = p)
+  colnames(X) <- paste0("x", seq_len(p))
+  q <- rep(1.0, n)
+
+  M <- PACS:::simulate_cumu_pacs(X = X, alpha = alpha, beta = beta,
+                                 q = q, capture = "B", seed = 200L)
+
+  ## --- ordinal::clm() ---
+  Y_factor <- factor(M, levels = 0:T, ordered = TRUE)
+  df <- data.frame(Y = Y_factor, x1 = X[, 1], x2 = X[, 2])
+  fit_clm <- ordinal::clm(Y ~ x1 + x2, data = df, link = "logit")
+
+  ## Map clm estimates to our parameterisation.
+  alpha_clm <- -as.numeric(fit_clm$alpha)
+  beta_clm <- as.numeric(fit_clm$beta)
+
+  ## Build theta in our (atilde, beta) space.
+  atilde_clm <- numeric(T)
+  atilde_clm[1] <- alpha_clm[1]
+  for (t in 2:T) {
+    atilde_clm[t] <- log(alpha_clm[t - 1] - alpha_clm[t])
+  }
+  theta_clm <- c(atilde_clm, beta_clm)
+
+  ## Our unpenalized log-likelihood at the clm MLE should match clm's logLik.
+  ## At q=1 our loss_fun_cumu drops the log(q_i) term for m>=1, but q=1 =>
+  ## log(1)=0, so no correction needed.
+  ll_ours <- PACS:::loss_fun_cumu(theta = theta_clm, X = X, M = M, q = q, T = T)
+  ll_clm <- as.numeric(logLik(fit_clm))
+
+  expect_equal(ll_ours, ll_clm, tolerance = 1e-6,
+               label = "unpenalized logLik at clm MLE, small n")
+
+  message(sprintf("n=80: logLik ours=%.6f, clm=%.6f, diff=%.2e",
+                  ll_ours, ll_clm, abs(ll_ours - ll_clm)))
+})
+
+
+test_that("at q=1 small n, score at clm MLE is zero", {
+  skip_on_cran()
+  skip_if_not_installed("ordinal")
+
+  set.seed(88L)
+  n <- 80L
+  T <- 2L
+  p <- 1L
+  alpha <- c(0.5, -0.5)
+  beta <- 0.4
+  X <- matrix(rnorm(n * p), nrow = n, ncol = p)
+  colnames(X) <- "x1"
+  q <- rep(1.0, n)
+
+  M <- PACS:::simulate_cumu_pacs(X = X, alpha = alpha, beta = beta,
+                                 q = q, capture = "B", seed = 300L)
+
+  Y_factor <- factor(M, levels = 0:T, ordered = TRUE)
+  df <- data.frame(Y = Y_factor, x1 = X[, 1])
+  fit_clm <- ordinal::clm(Y ~ x1, data = df, link = "logit")
+
+  alpha_clm <- -as.numeric(fit_clm$alpha)
+  beta_clm <- as.numeric(fit_clm$beta)
+
+  atilde_clm <- numeric(T)
+  atilde_clm[1] <- alpha_clm[1]
+  for (t in 2:T) {
+    atilde_clm[t] <- log(alpha_clm[t - 1] - alpha_clm[t])
+  }
+  theta_clm <- c(atilde_clm, beta_clm)
+
+  grad <- PACS:::loss_gradient_cumu(theta = theta_clm, X = X, M = M, q = q, T = T)
+  expect_equal(as.numeric(grad), rep(0, length(grad)), tolerance = 1e-4,
+               label = "score at clm MLE should be ~0")
+
+  message(sprintf("n=80: max |score| at clm MLE = %.2e", max(abs(grad))))
+})
+
+
+test_that("at q=1 Firth reduces bias vs clm MLE at small n (simulation)", {
+  skip_on_cran()
+  skip_if_not_installed("ordinal")
+
+  n_rep <- 40L
+  n <- 80L
+  T <- 2L
+  p <- 1L
+  alpha <- c(0.8, -0.4)
+  beta <- 0.5
+
+  beta_firth <- numeric(n_rep)
+  beta_clm <- numeric(n_rep)
+  ok_firth <- logical(n_rep)
+  ok_clm <- logical(n_rep)
+
+  for (r in seq_len(n_rep)) {
+    set.seed(400L + r)
+    X <- matrix(rnorm(n * p), nrow = n, ncol = p)
+    colnames(X) <- "x1"
+    q <- rep(1.0, n)
+    M <- PACS:::simulate_cumu_pacs(X = X, alpha = alpha, beta = beta,
+                                   q = q, capture = "B", seed = 500L + r)
+
+    ## Firth (our code)
+    theta_init <- PACS:::warm_start_theta(M = M, q = q, T = T, p_beta = p)
+    res <- PACS:::irls_iter_cumu(M_vec = M, X = X, theta_estimated = theta_init,
+                                 q_vec = q, T = T)
+    if (res[length(res)] == 1L) {
+      beta_firth[r] <- res[T + 1L]
+      ok_firth[r] <- TRUE
+    }
+
+    ## clm (unpenalized MLE)
+    Y_factor <- factor(M, levels = 0:T, ordered = TRUE)
+    df <- data.frame(Y = Y_factor, x1 = X[, 1])
+    fit <- try(ordinal::clm(Y ~ x1, data = df, link = "logit"), silent = TRUE)
+    if (!inherits(fit, "try-error") && fit$convergence$code == 0L) {
+      beta_clm[r] <- as.numeric(fit$beta)
+      ok_clm[r] <- TRUE
+    }
+  }
+
+  both_ok <- ok_firth & ok_clm
+  expect_gt(sum(both_ok), 0.7 * n_rep)
+
+  bias_firth <- mean(beta_firth[both_ok]) - beta
+  bias_clm <- mean(beta_clm[both_ok]) - beta
+
+  message(sprintf("n=80, %d reps: bias(Firth)=%.4f, bias(clm MLE)=%.4f",
+                  sum(both_ok), bias_firth, bias_clm))
+
+  ## Firth should have smaller absolute bias than unpenalized MLE.
+  expect_lte(abs(bias_firth), abs(bias_clm) + 0.02)
+})

--- a/tests/testthat/test-cumu-order-constraint.R
+++ b/tests/testthat/test-cumu-order-constraint.R
@@ -1,0 +1,40 @@
+## The reparameterisation alpha_t = atilde_1 - sum_{s=2..t} exp(atilde_s)
+## guarantees alpha_1 >= alpha_2 >= ... >= alpha_T by construction. This
+## test guards against a back-transform bug.
+
+test_that("fitted alpha respects the proportional-odds ordering", {
+  skip_on_cran()
+  n_rep <- 15L
+  for (r in seq_len(n_rep)) {
+    fx <- make_cumu_fixture(n = 250L, p = 2L, T = 2L,
+                            alpha = c(0.8, -0.4), beta = c(0.4, -0.3),
+                            seed = 500L + r)
+    M <- PACS:::simulate_cumu_pacs(X = fx$X, alpha = fx$alpha, beta = fx$beta,
+                                   q = fx$q, capture = "B", seed = 600L + r)
+    theta_init <- PACS:::warm_start_theta(M = M, q = fx$q, T = 2L, p_beta = 2L)
+    res <- PACS:::irls_iter_cumu(M_vec = M, X = fx$X,
+                                 theta_estimated = theta_init,
+                                 q_vec = fx$q, T = 2L)
+    if (res[length(res)] != 1L) next
+    alpha_hat <- PACS:::alpha_from_atilde(res[1:2])
+    expect_gte(alpha_hat[1], alpha_hat[2])
+  }
+})
+
+
+test_that("alpha_from_atilde / atilde_jacobian are consistent with FD", {
+  set.seed(7L)
+  for (T in 1:4) {
+    atilde <- rnorm(T, sd = 0.3)
+    J <- PACS:::atilde_jacobian(atilde)
+    h <- 1e-6
+    J_fd <- matrix(0, nrow = T, ncol = T)
+    for (s in seq_len(T)) {
+      a_p <- atilde; a_p[s] <- a_p[s] + h
+      a_m <- atilde; a_m[s] <- a_m[s] - h
+      J_fd[, s] <- (PACS:::alpha_from_atilde(a_p) -
+                    PACS:::alpha_from_atilde(a_m)) / (2 * h)
+    }
+    expect_equal(J, J_fd, tolerance = 1e-6)
+  }
+})

--- a/tests/testthat/test-cumu-power.R
+++ b/tests/testthat/test-cumu-power.R
@@ -1,0 +1,136 @@
+## Under the alternative (beta_group != 0), the exact cumulative-logit path
+## should have more power than the binary path (which discards threshold
+## information by collapsing M to 1[M >= 1]).
+##
+## This test simulates two-group data from the cumulative model with a
+## true group effect and compares rejection rates of exact vs binary at
+## nominal 5%. The power gain comes from the second threshold: cells with
+## M = 2 carry more evidence than cells with M = 1, but binary treats
+## them identically.
+##
+## We test at two effect sizes: moderate (beta = 0.4) and small (beta = 0.2),
+## and verify that the exact method's power advantage is present and grows
+## as the effect shrinks (where every bit of information matters more).
+
+test_that("exact has more power than binary under the alternative", {
+  skip_on_cran()
+
+  T <- 2L
+  alpha_true <- c(0.7, -0.3)
+  n <- 400L
+  n_rep <- 120L
+  nominal_alpha <- 0.05
+
+  effect_sizes <- c(0.4, 0.2)
+  power_exact <- numeric(length(effect_sizes))
+  power_binary <- numeric(length(effect_sizes))
+
+  for (e in seq_along(effect_sizes)) {
+    beta_group <- effect_sizes[e]
+
+    pv_exact <- numeric(n_rep)
+    pv_binary <- numeric(n_rep)
+    ok_exact <- logical(n_rep)
+    ok_binary <- logical(n_rep)
+
+    for (r in seq_len(n_rep)) {
+      set.seed(7000L + r + e * 1000L)
+      n_A <- n %/% 2L
+      n_B <- n - n_A
+      group <- c(rep(0L, n_A), rep(1L, n_B))
+      X <- matrix(group, ncol = 1L)
+      colnames(X) <- "group"
+      q <- runif(n, 0.4, 0.9)
+
+      M <- PACS:::simulate_cumu_pacs(
+        X = X, alpha = alpha_true, beta = beta_group,
+        q = q, capture = "B", seed = 8000L + r + e * 1000L
+      )
+
+      ## ---- Exact cumulative-logit ----
+      th_init <- PACS:::warm_start_theta(M = M, q = q, T = T, p_beta = 1L)
+      res_full <- PACS:::irls_iter_cumu(
+        M_vec = M, X = X, theta_estimated = th_init, q_vec = q, T = T
+      )
+      th_init_null <- th_init
+      th_init_null[3L] <- 0
+      res_null <- PACS:::irls_iter_cumu_null(
+        M_vec = M, X = X, theta_estimated = th_init_null,
+        hold_zero = 3L, q_vec = q, T = T
+      )
+      if (res_full[length(res_full)] == 1L &&
+          res_null[length(res_null)] == 1L) {
+        th_f <- res_full[1:3]
+        th_n <- res_null[1:3]
+        pv <- PACS:::compare_models_cumu(
+          x_full = X,
+          theta_estimated_full = matrix(th_f, ncol = 1L),
+          theta_estimated_null = matrix(th_n, ncol = 1L),
+          q_vec = q, c_by_r = matrix(M, ncol = 1L),
+          T = T, df_test = 1L, mc.cores = 1L
+        )
+        if (is.finite(pv) && pv >= 0 && pv <= 1) {
+          pv_exact[r] <- pv
+          ok_exact[r] <- TRUE
+        }
+      }
+
+      ## ---- Binary (M >= 1 only) ----
+      Z_bin <- as.integer(M >= 1L)
+      X_bin <- cbind(intercept = 1, X)
+      theta_init_b <- rep.int(0.05, ncol(X_bin))
+      res_b_full <- irls_iter(y_vec = Z_bin, xdumm = X_bin,
+                              theta_estimated = theta_init_b, q_vec = q)
+      theta_init_b_null <- rep.int(0.05, ncol(X_bin))
+      theta_init_b_null[2L] <- 0
+      res_b_null <- irls_iter_null(y_vec = Z_bin, xdumm = X_bin,
+                                   theta_estimated = theta_init_b_null,
+                                   hold_zero = 2L, q_vec = q)
+      if (res_b_full[length(res_b_full)] == 1L &&
+          res_b_null[length(res_b_null)] == 1L) {
+        th_bf <- res_b_full[seq_len(length(res_b_full) - 1L)]
+        th_bn <- res_b_null[seq_len(length(res_b_null) - 1L)]
+        pv_b <- compare_models(
+          x_full = X_bin,
+          theta_estimated_full = matrix(th_bf, ncol = 1L),
+          x_null = X_bin,
+          theta_estimated_null = matrix(th_bn, ncol = 1L),
+          q_vec = q, c_by_r = matrix(Z_bin, ncol = 1L),
+          df_test = 1L, mc.cores = 1L
+        )
+        if (is.finite(pv_b)) {
+          pv_binary[r] <- pv_b
+          ok_binary[r] <- TRUE
+        }
+      }
+    }
+
+    both_ok <- ok_exact & ok_binary
+    n_ok <- sum(both_ok)
+    expect_gt(n_ok, 0.7 * n_rep,
+              label = sprintf("convergence at beta=%.1f", beta_group))
+
+    power_exact[e] <- mean(pv_exact[both_ok] < nominal_alpha)
+    power_binary[e] <- mean(pv_binary[both_ok] < nominal_alpha)
+
+    message(sprintf(
+      "beta=%.1f, n=%d (%d reps): power exact=%.3f, binary=%.3f, gain=+%.1f%%",
+      beta_group, n, n_ok,
+      power_exact[e], power_binary[e],
+      100 * (power_exact[e] - power_binary[e])
+    ))
+  }
+
+  ## Exact should have at least as much power as binary at both effect sizes.
+  for (e in seq_along(effect_sizes)) {
+    expect_gte(power_exact[e] + 0.03, power_binary[e],
+               label = sprintf("exact power >= binary at beta=%.1f",
+                               effect_sizes[e]))
+  }
+
+  ## At both effect sizes, exact should have non-trivial power (> 10%).
+  expect_gt(power_exact[1], 0.10,
+            label = "exact detects moderate effect")
+  expect_gt(power_exact[2], 0.05,
+            label = "exact detects small effect above nominal")
+})

--- a/tests/testthat/test-cumu-type1-ordering.R
+++ b/tests/testthat/test-cumu-type1-ordering.R
@@ -1,0 +1,181 @@
+## Under the null (true beta_test = 0), the stacked method inflates type-1
+## error because it treats the nested indicators Z_{i1} >= Z_{i2} as
+## independent, double-counting each cell. The binary method (using only
+## M >= 1) is conservative because it discards threshold information.
+##
+## Expected ordering of rejection rates at any nominal level alpha:
+##   binary <= exact <= stacked
+##
+## Equivalently, the median p-value should satisfy:
+##   stacked <= exact <= binary
+##
+## We verify this across multiple sample sizes (n = 100, 300, 800).
+
+test_that("type-1 error ordering: binary <= exact <= stacked across sample sizes", {
+  skip_on_cran()
+
+  alpha_true <- c(0.7, -0.3)
+  beta_nuisance <- 0.4
+  beta_test <- 0.0  ## null hypothesis
+  T <- 2L
+  n_rep <- 150L
+  nominal_alpha <- 0.05
+
+  sample_sizes <- c(100L, 300L, 800L)
+
+  for (n in sample_sizes) {
+    pv_exact <- numeric(n_rep)
+    pv_stack <- numeric(n_rep)
+    pv_binary <- numeric(n_rep)
+    ok_exact <- logical(n_rep)
+    ok_stack <- logical(n_rep)
+    ok_binary <- logical(n_rep)
+
+    for (r in seq_len(n_rep)) {
+      set.seed(2000L + r + n)
+      X <- matrix(rnorm(n * 2L), nrow = n, ncol = 2L)
+      colnames(X) <- c("x1", "x2")
+      q <- runif(n, 0.4, 0.9)
+
+      M <- PACS:::simulate_cumu_pacs(
+        X = X, alpha = alpha_true,
+        beta = c(beta_nuisance, beta_test),
+        q = q, capture = "B", seed = 3000L + r + n
+      )
+
+      ## ---- Exact cumulative-logit path ----
+      th_init <- PACS:::warm_start_theta(M = M, q = q, T = T, p_beta = 2L)
+      res_full <- PACS:::irls_iter_cumu(
+        M_vec = M, X = X, theta_estimated = th_init, q_vec = q, T = T
+      )
+      th_init_null <- th_init
+      th_init_null[4L] <- 0
+      res_null <- PACS:::irls_iter_cumu_null(
+        M_vec = M, X = X, theta_estimated = th_init_null,
+        hold_zero = 4L, q_vec = q, T = T
+      )
+      if (res_full[length(res_full)] == 1L &&
+          res_null[length(res_null)] == 1L) {
+        th_f <- res_full[1:4]
+        th_n <- res_null[1:4]
+        pv <- PACS:::compare_models_cumu(
+          x_full = X,
+          theta_estimated_full = matrix(th_f, ncol = 1L),
+          theta_estimated_null = matrix(th_n, ncol = 1L),
+          q_vec = q, c_by_r = matrix(M, ncol = 1L),
+          T = T, df_test = 1L, mc.cores = 1L
+        )
+        if (is.finite(pv) && pv >= 0 && pv <= 1) {
+          pv_exact[r] <- pv
+          ok_exact[r] <- TRUE
+        }
+      }
+
+      ## ---- Stacked path (binary IRLS on duplicated rows) ----
+      ## Uses the same full-design-matrix + hold_zero approach as pacs_test_logit.
+      Z1 <- as.integer(M >= 1L)
+      Z2 <- as.integer(M >= 2L)
+      A <- diag(T)
+      X_alpha <- A[c(rep(1L, n), rep(2L, n)), , drop = FALSE]
+      X_stack <- cbind(X_alpha, rbind(X, X))
+      q_stack <- c(q, q)
+      Z_stack <- c(Z1, Z2)
+
+      ## Full stacked fit (all 4 params free: alpha1, alpha2, beta_x1, beta_x2)
+      theta_init_s <- rep.int(0.05, ncol(X_stack))
+      res_s_full <- irls_iter(y_vec = Z_stack, xdumm = X_stack,
+                              theta_estimated = theta_init_s, q_vec = q_stack)
+      ## Null stacked fit: hold beta_x2 (col 4) at zero, same design matrix
+      theta_init_s_null <- rep.int(0.05, ncol(X_stack))
+      theta_init_s_null[4L] <- 0
+      res_s_null <- irls_iter_null(y_vec = Z_stack, xdumm = X_stack,
+                                   theta_estimated = theta_init_s_null,
+                                   hold_zero = 4L, q_vec = q_stack)
+      if (res_s_full[length(res_s_full)] == 1L &&
+          res_s_null[length(res_s_null)] == 1L) {
+        th_sf <- res_s_full[seq_len(length(res_s_full) - 1L)]
+        th_sn <- res_s_null[seq_len(length(res_s_null) - 1L)]
+        pv_s <- compare_models(
+          x_full = X_stack,
+          theta_estimated_full = matrix(th_sf, ncol = 1L),
+          x_null = X_stack,
+          theta_estimated_null = matrix(th_sn, ncol = 1L),
+          q_vec = q_stack, c_by_r = matrix(Z_stack, ncol = 1L),
+          df_test = 1L, mc.cores = 1L
+        )
+        if (is.finite(pv_s)) {
+          pv_stack[r] <- pv_s
+          ok_stack[r] <- TRUE
+        }
+      }
+
+      ## ---- Binary path (only Z1 = 1[M >= 1]) ----
+      ## Uses full design matrix + hold_zero, matching pacs_test_logit convention.
+      Z_bin <- as.integer(M >= 1L)
+      X_bin <- cbind(intercept = 1, X)  ## 3 cols: intercept, x1, x2
+
+      ## Full binary fit (intercept + x1 + x2)
+      theta_init_b <- rep.int(0.05, ncol(X_bin))
+      res_b_full <- irls_iter(y_vec = Z_bin, xdumm = X_bin,
+                              theta_estimated = theta_init_b, q_vec = q)
+      ## Null binary fit: hold x2 (col 3) at zero, same design matrix
+      theta_init_b_null <- rep.int(0.05, ncol(X_bin))
+      theta_init_b_null[3L] <- 0
+      res_b_null <- irls_iter_null(y_vec = Z_bin, xdumm = X_bin,
+                                   theta_estimated = theta_init_b_null,
+                                   hold_zero = 3L, q_vec = q)
+      if (res_b_full[length(res_b_full)] == 1L &&
+          res_b_null[length(res_b_null)] == 1L) {
+        th_bf <- res_b_full[seq_len(length(res_b_full) - 1L)]
+        th_bn <- res_b_null[seq_len(length(res_b_null) - 1L)]
+        pv_b <- compare_models(
+          x_full = X_bin,
+          theta_estimated_full = matrix(th_bf, ncol = 1L),
+          x_null = X_bin,
+          theta_estimated_null = matrix(th_bn, ncol = 1L),
+          q_vec = q, c_by_r = matrix(Z_bin, ncol = 1L),
+          df_test = 1L, mc.cores = 1L
+        )
+        if (is.finite(pv_b)) {
+          pv_binary[r] <- pv_b
+          ok_binary[r] <- TRUE
+        }
+      }
+    }
+
+    all_ok <- ok_exact & ok_stack & ok_binary
+    n_ok <- sum(all_ok)
+    expect_gt(n_ok, 0.6 * n_rep,
+              label = sprintf("convergence rate at n=%d", n))
+
+    rej_exact <- mean(pv_exact[all_ok] < nominal_alpha)
+    rej_stack <- mean(pv_stack[all_ok] < nominal_alpha)
+    rej_binary <- mean(pv_binary[all_ok] < nominal_alpha)
+
+    med_exact <- median(pv_exact[all_ok])
+    med_stack <- median(pv_stack[all_ok])
+    med_binary <- median(pv_binary[all_ok])
+
+    message(sprintf(
+      paste0("n=%d (%d reps): rejection rate at alpha=%.2f: ",
+             "binary=%.3f, exact=%.3f, stacked=%.3f  |  ",
+             "median p: binary=%.3f, exact=%.3f, stacked=%.3f"),
+      n, n_ok, nominal_alpha,
+      rej_binary, rej_exact, rej_stack,
+      med_binary, med_exact, med_stack
+    ))
+
+    ## Core assertion: stacked rejection rate >= exact (with slack for noise).
+    expect_gte(rej_stack + 0.03, rej_exact,
+               label = sprintf("stacked >= exact rejection at n=%d", n))
+    ## Exact rejection rate >= binary (with slack).
+    expect_gte(rej_exact + 0.05, rej_binary,
+               label = sprintf("exact >= binary rejection at n=%d", n))
+
+    ## Median p-value ordering: binary >= exact >= stacked (with slack).
+    expect_gte(med_binary + 0.10, med_exact,
+               label = sprintf("binary median p >= exact at n=%d", n))
+    expect_gte(med_exact + 0.10, med_stack,
+               label = sprintf("exact median p >= stacked at n=%d", n))
+  }
+})


### PR DESCRIPTION
## Summary

Two commits on this branch:

1. **`58587bd` Math design note** (`notes/cumulative_logit_math.md`) — derives the proper proportional-odds likelihood with capture-rate correction, plus score, Fisher information, Firth penalty, order-constraint reparameterisation, and the LRT. Includes a precise `T = 1` reduction to existing binary PACS as a parity test target. Two reviewer rounds caught and fixed a Fisher-information algebra bug; the corrected formulas now reduce to existing `infor_mat` exactly at `T = 1`.

2. **`e6535da` Implementation + tests + CI** — Option B fitting routines, cumulative LRT, simulation harness, parity/recovery/calibration tests, and an R-CMD-check workflow.

## Why

`pacs_test_cumu` currently uses a "stack-and-treat-as-binary" approximation (each cell duplicated `T` times across thresholds, fed into the binary IRLS). That is not a valid likelihood — `Z_{i1} ≥ Z_{i2} ≥ … ≥ Z_{iT}` is nested, so cells are double-counted, β estimates are biased, and the LRT df is wrong. The exact path corrects all three.

## Implementation

- `R/param_estimate_cumu.R` — link, score, Fisher info, Firth penalty, IRLS (full + null) on the order-constraint reparameterisation `α_t = ã_1 − Σ_{s=2..t} exp(ã_s)`. Internal helpers; not exported.
- `R/sim_cumu.R` — `simulate_cumu_pacs()` draws from Option B (with prob `q_i` sample from the proportional-odds multinomial; else `M_i = 0`).
- `R/PACS_test_cumulative.R` — `pacs_test_cumu(method = c("stacked", "exact"))`. **Default stays `"stacked"`** for back-compat; the exact path strips the row-stacking entirely.
- `R/differential_identification.R` — `compare_models_cumu()` computes the Firth-corrected LRT under the cumulative likelihood, and warns on peaks that hit the order-constraint boundary.

## Tests (`tests/testthat/`)

- `test-cumu-T1-parity.R` — at `T = 1`, every new function reduces to the corresponding binary function (exact agreement on score & info; ≤ 1e-4 on IRLS due to FD on the Firth-penalty score).
- `test-cumu-T2-recovery.R` — 30 reps × n=400; bias on α and β below 0.15.
- `test-cumu-T2-stacked-vs-exact.R` — informational MSE comparison.
- `test-cumu-order-constraint.R` — `α_1 ≥ α_2` always; Jacobian agrees with FD.
- `test-cumu-LRT.R` — 100 null reps; KS p-value uniformity check.

## CI

`.github/workflows/R-CMD-check.yaml` runs on push and PR (no `--as-cran`; regenerates roxygen docs before check).

## Out of scope (follow-up PRs)

- **Option A** (fragment-level thinning) — Phase 3 of the math note's §10.
- Switching the default to `method = "exact"` — Phase 4.
- Any change to `pacs_test_logit`.

## Test plan

- [ ] R-CMD-check workflow green on push.
- [ ] Author cross-checks the math note against the published mcCLR section.
- [ ] Confirm bias on β goes the expected direction in `test-cumu-T2-stacked-vs-exact.R`.

https://claude.ai/code/session_01VUvU3wnvnAVTtTZDAdLuGv